### PR TITLE
accounts: Check if 'to' address is reserved

### DIFF
--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -302,7 +302,7 @@ var (
 
 			// Check, if to address is known to be unspendable.
 			if toAddr != nil {
-				cobra.CheckErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
+				common.CheckForceErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
 			}
 
 			// Parse amount.
@@ -408,7 +408,7 @@ var (
 			cobra.CheckErr(common.CheckLocalAccountIsConsensusCapable(cfg, addrToCheck))
 
 			// Check, if to address is known to be unspendable.
-			cobra.CheckErr(common.CheckAddressNotReserved(cfg, addrToCheck))
+			common.CheckForceErr(common.CheckAddressNotReserved(cfg, addrToCheck))
 
 			// Parse amount.
 			// TODO: This should actually query the ParaTime (or config) to check what the consensus
@@ -494,7 +494,7 @@ var (
 			cobra.CheckErr(err)
 
 			// Check, if to address is known to be unspendable.
-			cobra.CheckErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
+			common.CheckForceErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
 
 			acc := common.LoadAccount(cfg, npa.AccountName)
 
@@ -856,12 +856,15 @@ func init() {
 
 	accountsDepositCmd.Flags().AddFlagSet(common.SelectorFlags)
 	accountsDepositCmd.Flags().AddFlagSet(common.TransactionFlags)
+	accountsDepositCmd.Flags().AddFlagSet(common.ForceFlag)
 
 	accountsWithdrawCmd.Flags().AddFlagSet(common.SelectorFlags)
 	accountsWithdrawCmd.Flags().AddFlagSet(common.TransactionFlags)
+	accountsWithdrawCmd.Flags().AddFlagSet(common.ForceFlag)
 
 	accountsTransferCmd.Flags().AddFlagSet(common.SelectorFlags)
 	accountsTransferCmd.Flags().AddFlagSet(common.TransactionFlags)
+	accountsTransferCmd.Flags().AddFlagSet(common.ForceFlag)
 
 	accountsBurnCmd.Flags().AddFlagSet(common.SelectorFlags)
 	accountsBurnCmd.Flags().AddFlagSet(common.TransactionFlags)

--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -300,6 +300,11 @@ var (
 				cobra.CheckErr(err)
 			}
 
+			// Check, if to address is known to be unspendable.
+			if toAddr != nil {
+				cobra.CheckErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
+			}
+
 			// Parse amount.
 			// TODO: This should actually query the ParaTime (or config) to check what the consensus
 			//       layer denomination is in the ParaTime. Assume NATIVE for now.
@@ -402,6 +407,9 @@ var (
 
 			cobra.CheckErr(common.CheckLocalAccountIsConsensusCapable(cfg, addrToCheck))
 
+			// Check, if to address is known to be unspendable.
+			cobra.CheckErr(common.CheckAddressNotReserved(cfg, addrToCheck))
+
 			// Parse amount.
 			// TODO: This should actually query the ParaTime (or config) to check what the consensus
 			//       layer denomination is in the ParaTime. Assume NATIVE for now.
@@ -484,6 +492,9 @@ var (
 			// Resolve destination address.
 			toAddr, err := common.ResolveLocalAccountOrAddress(npa.Network, to)
 			cobra.CheckErr(err)
+
+			// Check, if to address is known to be unspendable.
+			cobra.CheckErr(common.CheckAddressNotReserved(cfg, toAddr.String()))
 
 			acc := common.LoadAccount(cfg, npa.AccountName)
 

--- a/cmd/common/flags.go
+++ b/cmd/common/flags.go
@@ -10,13 +10,22 @@ import (
 )
 
 var selectedHeight int64
+var force bool
 
 // HeightFlag is the flag for specifying block height.
 var HeightFlag *flag.FlagSet
 
+// ForceFlag is a force mode switch.
+var ForceFlag *flag.FlagSet
+
 // GetHeight returns the user-selected block height.
 func GetHeight() int64 {
 	return selectedHeight
+}
+
+// IsForce returns force mode.
+func IsForce() bool {
+	return force
 }
 
 // GetActualHeight returns the user-selected block height if explicitly
@@ -39,4 +48,7 @@ func GetActualHeight(
 func init() {
 	HeightFlag = flag.NewFlagSet("", flag.ContinueOnError)
 	HeightFlag.Int64Var(&selectedHeight, "height", consensus.HeightLatest, "explicitly set block height to use")
+
+	ForceFlag = flag.NewFlagSet("", flag.ContinueOnError)
+	ForceFlag.BoolVarP(&force, "force", "f", false, "treat safety check errors as warnings")
 }

--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// CheckForceErr treats error as warning, if --force is provided.
+func CheckForceErr(err interface{}) {
+	// No error.
+	if err == nil {
+		return
+	}
+
+	// --force is provided.
+	if IsForce() {
+		fmt.Printf("Warning: %s\nProceeding by force as requested\n", err)
+		return
+	}
+
+	// Print error with --force hint and quit.
+	errMsg := fmt.Sprintf("%s", err)
+	errMsg += "\nUse --force to ignore this check"
+	cobra.CheckErr(errMsg)
+}


### PR DESCRIPTION
Fixes oasisprotocol/cli#7.

This PR checks, if the `to` address for Transfers, Withdrawals and Deposits is a known unspendable address:
  - rewards pool address
  - common pool address
  - fee accumulator address
  - governance deposit address
  - native ParaTime address

User can override the check by passing `--force` switch.

Example:
```
$ oasis accounts transfer 10 pool:rewards
Error: address 'oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav' is rewards pool address
Use --force to ignore this check
$ oasis accounts deposit 10 paratime:emerald
Error: did you mean --paratime emerald? Address 'oasis1qr629x0tg9gm5fyhedgs9lw5eh3d8ycdnsxf0run' is native address of paratime:emerald on testnet and should not be transferred to directly
Use --force to ignore this check
$ oasis accounts deposit 10 oasis1qr629x0tg9gm5fyhedgs9lw5eh3d8ycdnsxf0run
Error: did you mean --paratime emerald? Address 'oasis1qr629x0tg9gm5fyhedgs9lw5eh3d8ycdnsxf0run' is native address of paratime:emerald on testnet and should not be transferred to directly
Use --force to ignore this check
$ oasis accounts deposit 10 paratime:emerald -f
Warning: did you mean --paratime emerald? Address 'oasis1qr629x0tg9gm5fyhedgs9lw5eh3d8ycdnsxf0run' is native address of paratime:emerald on testnet and should not be transferred to directly
Proceeding by force as requested
You are about to sign the following transaction:
{
  "v": 1,
  "call": {
    "method": "consensus.Deposit",
    "body": "omJ0b1UA9KKZ60FRuiSXy1EC/dTN4tOTDZxmYW1vdW50gkUCVAvkAEA="
  },
  "ai": {
    "si": [
      {
        "address_spec": {
          "signature": {
            "ed25519": "MJ2XCjkj132C9YWpDUSQFjkCTI8bSw8bi0w9EwwE1Bg="
          }
        },
        "nonce": 3
      }
    ],
    "fee": {
      "amount": {
        "Amount": "2001535",
        "Denomination": ""
      },
      "gas": 400307,
      "consensus_messages": 1
    }
  }
}

Account:  test:alice
Network:  testnet
Paratime: cipher
? Sign this transaction? (y/N)
```