### PR TITLE
Prevent funding explicit ethereum addresses on consensus

### DIFF
--- a/cmd/common/wallet.go
+++ b/cmd/common/wallet.go
@@ -96,10 +96,13 @@ func ResolveLocalAccountOrAddress(net *configSdk.Network, address string) (*type
 	return helpers.ResolveAddress(net, address)
 }
 
-// CheckLocalAccountIsConsensusCapable is a safety check for withdrawals or consensus layer
-// transfers to potentially known native addresses which key pairs are not compatible with
-// consensus or the address is a derivation of a known Ethereum address.
-func CheckLocalAccountIsConsensusCapable(cfg *config.Config, address string) error {
+// CheckAddressIsConsensusCapable checks whether the given address is derived from any known
+// Ethereum address and is thus unspendable on consensus layer.
+func CheckAddressIsConsensusCapable(cfg *config.Config, address string) error {
+	if ethCommon.IsHexAddress(address) {
+		return fmt.Errorf("signer for address '%s' will not be able to sign transactions on consensus layer", address)
+	}
+
 	for name, acc := range cfg.Wallet.All {
 		if acc.Address == address && !acc.HasConsensusSigner() {
 			return fmt.Errorf("destination account '%s' (%s) will not be able to sign transactions on consensus layer", name, acc.Address)
@@ -115,7 +118,7 @@ func CheckLocalAccountIsConsensusCapable(cfg *config.Config, address string) err
 
 	for name, acc := range cfg.AddressBook.All {
 		if acc.Address == address && acc.GetEthAddress() != nil {
-			return fmt.Errorf("destination address named '%s' (%s) will not be able to sign transactions on consensus layer", name, acc.GetEthAddress().Hex())
+			return fmt.Errorf("signer for address named '%s' (%s) will not be able to sign transactions on consensus layer", name, acc.GetEthAddress().Hex())
 		}
 	}
 


### PR DESCRIPTION
Fixes #23 .

Depends on https://github.com/oasisprotocol/cli/pull/11.

Before:
```
$ oasis accounts transfer 0.1 0xDce075E1C39b1ae0b75D554558b6451A226ffe12 --no-paratime
You are about to sign the following transaction:
Method: staking.Transfer
Body:
  To:     oasis1qqxlf9za3py8d6462wkwm49r4t294slncy97zhlr
  Amount: 0.1 TEST
Nonce:  7
Fee:
  Amount: 0.0 TEST
  Gas limit: 1264
  (gas price: 0.0 TEST per gas unit)

Network:  testnet
ParaTime: none (consensus layer)
Account:  test

$ oasis accounts withdraw 0.1 0xDce075E1C39b1ae0b75D554558b6451A226ffe12
You are about to sign the following transaction:
Format: plain
Method: consensus.Withdraw
Body:
  To: oasis1qqxlf9za3py8d6462wkwm49r4t294slncy97zhlr
  Amount: 0.1 TEST
Authorized signer(s):
  1. MJ2XCjkj132C9YWpDUSQFjkCTI8bSw8bi0w9EwwE1Bg= (ed25519)
     Nonce: 0
Fee:
  Amount: 0.0011311 TEST
  Gas limit: 11311
  (gas price: 0.0000001 TEST per gas unit)

Network:  testnet
ParaTime: sapphire
Account:  test
```

After:
```
$ oasis accounts transfer 0.1 0xDce075E1C39b1ae0b75D554558b6451A226ffe12 --no-paratime
Error: signer for address '0xdCe075E1C39b1AE0b75d554558B6451a226FFE12' will not be able to sign transactions on consensus layer
Use --force to ignore this check
$ oasis accounts withdraw 0.1 0xDce075E1C39b1ae0b75D554558b6451A226ffe12
Error: signer for address '0xdCe075E1C39b1AE0b75d554558B6451a226FFE12' will not be able to sign transactions on consensus layer
Use --force to ignore this check
```