### PR TITLE
ci: undisable cgo on release build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,8 +6,6 @@ before:
 
 builds:
   - binary: oasis
-    env:
-      - CGO_ENABLED=0
     flags:
       - -trimpath
     ldflags:


### PR DESCRIPTION
commit message
> without cgo, we can't use ledger. the library does not link to libusb and always answers that no devices are connected.
https://github.com/Zondax/hid/blob/v0.9.1/hid_disabled.go#L7
this CLI is intended to work with ledger, so we're enabling this.

we're not aware of anything that specifically needed a non-cgo build. but if anyone depended on the program not being with cgo, you're welcome to comment.