### PR TITLE
fix(cmd): Don't crash when event channel is closed

### DIFF
--- a/cmd/common/transaction.go
+++ b/cmd/common/transaction.go
@@ -437,6 +437,10 @@ func WaitForEvent(
 			case <-ctx.Done():
 				return
 			case bev := <-ch:
+				if bev == nil {
+					return
+				}
+
 				for _, ev := range bev.Events {
 					if result := mapFn(ev); result != nil {
 						resultCh <- result


### PR DESCRIPTION
Fixes #57 