### PR TITLE
fix(cmd): Add checks for unique account/ab name

### DIFF
--- a/cmd/addressbook.go
+++ b/cmd/addressbook.go
@@ -12,8 +12,9 @@ import (
 
 var (
 	addressBookCmd = &cobra.Command{
-		Use:   "addressbook",
-		Short: "Manage addresses in the local address book",
+		Use:     "addressbook",
+		Aliases: []string{"ab"},
+		Short:   "Manage addresses in the local address book",
 	}
 
 	abListCmd = &cobra.Command{
@@ -57,6 +58,9 @@ var (
 			name := args[0]
 			address := args[1]
 
+			if _, exists := cfg.Wallet.All[name]; exists {
+				cobra.CheckErr(fmt.Errorf("account '%s' already exists in the wallet", name))
+			}
 			err := cfg.AddressBook.Add(name, address)
 			cobra.CheckErr(err)
 
@@ -85,8 +89,8 @@ var (
 	}
 
 	abRmCmd = &cobra.Command{
-		Use:     "rm <name>",
-		Aliases: []string{"remove"},
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
 		Short:   "Remove an address from address book",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -102,13 +106,17 @@ var (
 	}
 
 	abRenameCmd = &cobra.Command{
-		Use:   "rename <old> <new>",
-		Short: "Rename address",
-		Args:  cobra.ExactArgs(2),
+		Use:     "rename <old> <new>",
+		Aliases: []string{"mv"},
+		Short:   "Rename address",
+		Args:    cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()
 			oldName, newName := args[0], args[1]
 
+			if _, exists := cfg.Wallet.All[newName]; exists {
+				cobra.CheckErr(fmt.Errorf("account '%s' already exists in the wallet", newName))
+			}
 			err := cfg.AddressBook.Rename(oldName, newName)
 			cobra.CheckErr(err)
 

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -156,6 +156,9 @@ var (
 			cfg := config.Global()
 			oldName, newName := args[0], args[1]
 
+			if _, exists := cfg.AddressBook.All[newName]; exists {
+				cobra.CheckErr(fmt.Errorf("address named '%s' already exists in the address book", newName))
+			}
 			err := cfg.Wallet.Rename(oldName, newName)
 			cobra.CheckErr(err)
 

--- a/config/addressbook.go
+++ b/config/addressbook.go
@@ -52,11 +52,11 @@ func (ab *AddressBook) Remove(name string) error {
 func (ab *AddressBook) Rename(old, new string) error {
 	cfg, exists := ab.All[old]
 	if !exists {
-		return fmt.Errorf("address named '%s' does not exist", old)
+		return fmt.Errorf("address named '%s' does not exist in the address book", old)
 	}
 
 	if _, exists = ab.All[new]; exists {
-		return fmt.Errorf("address named '%s' already exists", new)
+		return fmt.Errorf("address named '%s' already exists in the address book", new)
 	}
 
 	if err := config.ValidateIdentifier(old); err != nil {

--- a/config/wallet.go
+++ b/config/wallet.go
@@ -159,11 +159,11 @@ func (w *Wallet) Remove(name string) error {
 func (w *Wallet) Rename(old, new string) error {
 	cfg, exists := w.All[old]
 	if !exists {
-		return fmt.Errorf("account '%s' does not exist", old)
+		return fmt.Errorf("account '%s' does not exist in the wallet", old)
 	}
 
 	if _, exists = w.All[new]; exists {
-		return fmt.Errorf("account '%s' already exists", new)
+		return fmt.Errorf("account '%s' already exists in the wallet", new)
 	}
 
 	if err := config.ValidateIdentifier(old); err != nil {


### PR DESCRIPTION
Previously, you could have duplicate name entries inside your wallet and inside your address book. This caused ambiguity when selecting destination account. This PR adds a check when creating or renaming address book entries.

Also adds alias `ab` for `addressbook`.