### PR TITLE
fix(cmd): Always use long name for usage and shorthand alias

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -142,8 +142,8 @@ var (
 	}
 
 	networkRmCmd = &cobra.Command{
-		Use:     "rm <name>",
-		Aliases: []string{"remove"},
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
 		Short:   "Remove an existing network",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/paratime.go
+++ b/cmd/paratime.go
@@ -125,8 +125,8 @@ var (
 	}
 
 	paratimeRmCmd = &cobra.Command{
-		Use:     "rm <network> <name>",
-		Aliases: []string{"remove"},
+		Use:     "remove <network> <name>",
+		Aliases: []string{"rm"},
 		Short:   "Remove an existing paratime",
 		Args:    cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -21,8 +21,9 @@ import (
 
 var (
 	txCmd = &cobra.Command{
-		Use:   "tx",
-		Short: "Raw transaction operations",
+		Use:     "transaction",
+		Aliases: []string{"tx"},
+		Short:   "Raw transaction operations",
 	}
 
 	txSubmitCmd = &cobra.Command{

--- a/cmd/wallet.go
+++ b/cmd/wallet.go
@@ -33,8 +33,8 @@ var (
 	}
 
 	walletListCmd = &cobra.Command{
-		Use:     "ls",
-		Aliases: []string{"list"},
+		Use:     "list",
+		Aliases: []string{"ls"},
 		Short:   "List configured accounts",
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -111,8 +111,8 @@ var (
 	}
 
 	walletRmCmd = &cobra.Command{
-		Use:     "rm <name>",
-		Aliases: []string{"remove"},
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
 		Short:   "Remove an existing account",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -148,9 +148,9 @@ var (
 	}
 
 	walletRenameCmd = &cobra.Command{
-		Use:     "mv <old> <new>",
+		Use:     "rename <old> <new>",
 		Short:   "Rename an existing account",
-		Aliases: []string{"rename"},
+		Aliases: []string{"mv"},
 		Args:    cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := config.Global()


### PR DESCRIPTION
Currently, the usage is sometimes shorthand, sometimes whole word. This PR now always use long names for the usage and shorthand for alias(es).