### PR TITLE
feat(cmd): Add inspect block subcommand to inspect blocks

### DIFF
--- a/cmd/common/transaction.go
+++ b/cmd/common/transaction.go
@@ -270,7 +270,7 @@ func SignParaTimeTransaction(
 }
 
 // PrintTransaction prints the transaction which can be either signed or unsigned.
-func PrintTransaction(npa *NPASelection, tx interface{}) {
+func PrintTransactionRaw(npa *NPASelection, tx interface{}) {
 	switch rtx := tx.(type) {
 	case consensusPretty.PrettyPrinter:
 		// Signed or unsigned consensus or runtime transaction.
@@ -299,6 +299,12 @@ func PrintTransaction(npa *NPASelection, tx interface{}) {
 	default:
 		fmt.Printf("[unsupported transaction type: %T]\n", tx)
 	}
+}
+
+// PrintTransaction prints the transaction which can be either signed or unsigned together with
+// information about the selected network/paratime.
+func PrintTransaction(npa *NPASelection, tx interface{}) {
+	PrintTransactionRaw(npa, tx)
 
 	fmt.Println()
 	fmt.Printf("Network:  %s", npa.NetworkName)

--- a/cmd/inspect/block.go
+++ b/cmd/inspect/block.go
@@ -1,0 +1,267 @@
+package inspect
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
+	"github.com/oasisprotocol/cli/cmd/common"
+	cliConfig "github.com/oasisprotocol/cli/config"
+)
+
+const (
+	blockLatest = "latest"
+)
+
+var blockCmd = &cobra.Command{
+	Use:   "block <number> [ <tx-index> | <tx-hash> ]",
+	Short: "Show information about a block and its transactions",
+	Long:  "Show information about a given block number and (optionally) its transactions. Use \"latest\" to use the last block.",
+	Args:  cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := cliConfig.Global()
+		npa := common.GetNPASelection(cfg)
+
+		var (
+			err     error
+			blkNum  uint64
+			txIndex int
+			txHash  hash.Hash
+		)
+		switch blkNumRaw := args[0]; blkNumRaw {
+		case blockLatest:
+			// The latest block.
+			blkNum = client.RoundLatest // TODO: Support consensus.
+		default:
+			// A specific block.
+			blkNum, err = strconv.ParseUint(blkNumRaw, 10, 64)
+			if err != nil {
+				cobra.CheckErr(fmt.Errorf("malformed block number: %w", err))
+			}
+		}
+
+		if len(args) >= 2 {
+			txIndexOrHash := args[1]
+
+			txIndex, err = strconv.Atoi(txIndexOrHash)
+			if err != nil {
+				txIndex = -1
+				if err = txHash.UnmarshalHex(txIndexOrHash); err != nil {
+					cobra.CheckErr(fmt.Errorf("malformed tx hash: %w", err))
+				}
+			}
+		}
+
+		// Establish connection with the target network.
+		ctx := context.Background()
+		conn, err := connection.Connect(ctx, npa.Network)
+		cobra.CheckErr(err)
+
+		fmt.Printf("Network:        %s", npa.NetworkName)
+		if len(npa.Network.Description) > 0 {
+			fmt.Printf(" (%s)", npa.Network.Description)
+		}
+		fmt.Println()
+
+		switch npa.ParaTime {
+		case nil:
+			// Consensus layer.
+			cobra.CheckErr("inspecting consensus layer blocks not yet supported") // TODO
+		default:
+			// Runtime layer.
+			rt := conn.Runtime(npa.ParaTime)
+
+			evDecoders := []client.EventDecoder{
+				rt.Accounts,
+				rt.ConsensusAccounts,
+				rt.Contracts,
+				rt.Evm,
+			}
+
+			blk, err := rt.GetBlock(ctx, blkNum)
+			cobra.CheckErr(err)
+
+			fmt.Printf("ParaTime:       %s", npa.ParaTimeName)
+			if len(npa.ParaTime.Description) > 0 {
+				fmt.Printf(" (%s)", npa.ParaTime.Description)
+			}
+			fmt.Println()
+			fmt.Printf("Round:          %d\n", blk.Header.Round)
+			fmt.Printf("Version:        %d\n", blk.Header.Version)
+			fmt.Printf("Namespace:      %s\n", blk.Header.Namespace)
+
+			// TODO: Fix when timestamp has a String method.
+			ts, _ := blk.Header.Timestamp.MarshalText()
+			fmt.Printf("Timestamp:      %s\n", string(ts))
+
+			// TODO: Fix when type has a String method.
+			fmt.Printf("Type:           %d\n", blk.Header.HeaderType)
+			fmt.Printf("Previous:       %s\n", blk.Header.PreviousHash)
+			fmt.Printf("I/O root:       %s\n", blk.Header.IORoot)
+			fmt.Printf("State root:     %s\n", blk.Header.StateRoot)
+			fmt.Printf("Messages (out): %s\n", blk.Header.MessagesHash)
+			fmt.Printf("Messages (in):  %s\n", blk.Header.InMessagesHash)
+
+			txs, err := rt.GetTransactionsWithResults(ctx, blk.Header.Round)
+			cobra.CheckErr(err)
+
+			fmt.Printf("Transactions:   %d\n", len(txs))
+
+			if len(args) >= 2 {
+				fmt.Println()
+
+				// Resolve transaction index if needed.
+				if txIndex == -1 {
+					for i, tx := range txs {
+						if h := tx.Tx.Hash(); h.Equal(&txHash) {
+							txIndex = i
+							break
+						}
+					}
+
+					if txIndex == -1 {
+						cobra.CheckErr(fmt.Errorf("failed to find transaction with hash %s", txHash))
+					}
+				}
+
+				if txIndex >= len(txs) {
+					cobra.CheckErr(fmt.Errorf("transaction index %d is out of range", txIndex))
+				}
+				tx := txs[txIndex]
+
+				fmt.Printf("=== Transaction %d ===\n", txIndex)
+
+				if len(tx.Tx.AuthProofs) == 1 && tx.Tx.AuthProofs[0].Module != "" {
+					// Module-specific transaction encoding scheme.
+					scheme := tx.Tx.AuthProofs[0].Module
+
+					switch scheme {
+					case "evm.ethereum.v0":
+						// Ethereum transaction encoding.
+						var ethTx ethTypes.Transaction
+						if err := ethTx.UnmarshalBinary(tx.Tx.Body); err != nil {
+							fmt.Printf("[malformed 'evm.ethereum.v0' transaction: %s]\n", err)
+							break
+						}
+
+						fmt.Printf("Kind:      evm.ethereum.v0\n")
+						fmt.Printf("Hash:      %s\n", tx.Tx.Hash())
+						fmt.Printf("Eth hash:  %s\n", ethTx.Hash())
+						fmt.Printf("Chain ID:  %s\n", ethTx.ChainId())
+						fmt.Printf("Nonce:     %d\n", ethTx.Nonce())
+						fmt.Printf("Type:      %d\n", ethTx.Type())
+						fmt.Printf("To:        %s\n", ethTx.To())
+						fmt.Printf("Value:     %s\n", ethTx.Value())
+						fmt.Printf("Gas limit: %d\n", ethTx.Gas())
+						fmt.Printf("Gas price: %s\n", ethTx.GasPrice())
+						fmt.Printf("Data:\n")
+						if len(ethTx.Data()) > 0 {
+							fmt.Printf("  %s\n", base64.StdEncoding.EncodeToString(ethTx.Data()))
+						} else {
+							fmt.Printf("  (none)\n")
+						}
+					default:
+						fmt.Printf("[module-specific transaction encoding scheme: %s]\n", scheme)
+					}
+				} else {
+					// Regular SDK transaction.
+					fmt.Printf("Kind: oasis\n")
+
+					common.PrintTransactionRaw(npa, &tx.Tx)
+				}
+				fmt.Println()
+
+				// Show result.
+				fmt.Printf("=== Result of transaction %d ===\n", txIndex)
+				switch res := tx.Result; {
+				case res.Failed != nil:
+					fmt.Printf("Status:  failed\n")
+					fmt.Printf("Module:  %s\n", res.Failed.Module)
+					fmt.Printf("Code:    %d\n", res.Failed.Code)
+					fmt.Printf("Message: %s\n", res.Failed.Message)
+				case res.Ok != nil:
+					fmt.Printf("Status: ok\n")
+					fmt.Printf("Data:\n")
+					prettyPrintCBOR("  ", res.Ok)
+				case res.Unknown != nil:
+					fmt.Printf("Status: unknown\n")
+					fmt.Printf("Data:\n")
+					prettyPrintCBOR("  ", res.Unknown)
+				default:
+					fmt.Printf("[unsupported result kind]\n")
+				}
+				fmt.Println()
+
+				// Show events.
+				fmt.Printf("=== Events emitted by transaction %d ===\n", txIndex)
+				if numEvents := len(tx.Events); numEvents > 0 {
+					fmt.Printf("Events: %d\n", numEvents)
+					fmt.Println()
+
+					for evIndex, ev := range tx.Events {
+						prettyPrintEvent("  ", evIndex, ev, evDecoders)
+						fmt.Println()
+					}
+				} else {
+					fmt.Println("No events emitted by this transaction.")
+				}
+			}
+		}
+	},
+}
+
+func prettyPrintCBOR(indent string, data []byte) {
+	var body interface{}
+	if err := cbor.Unmarshal(data, &body); err != nil {
+		fmt.Printf("%s%s\n", indent, base64.StdEncoding.EncodeToString(data))
+		return
+	}
+
+	prettyPrintStruct(indent, data, body)
+}
+
+func prettyPrintStruct(indent string, data []byte, body interface{}) {
+	// TODO: Support the pretty printer.
+	pretty, err := yaml.Marshal(body)
+	if err != nil {
+		fmt.Printf("%s%s\n", indent, base64.StdEncoding.EncodeToString(data))
+		return
+	}
+
+	output := string(pretty)
+	output = strings.ReplaceAll(output, "\n", "\n"+indent)
+	output = strings.TrimSpace(output)
+	fmt.Println(indent + output)
+}
+
+func prettyPrintEvent(indent string, evIndex int, ev *types.Event, decoders []client.EventDecoder) {
+	fmt.Printf("%s--- Event %d ---\n", indent, evIndex)
+	fmt.Printf("%sModule: %s\n", indent, ev.Module)
+	fmt.Printf("%sCode:   %d\n", indent, ev.Code)
+	fmt.Printf("%sData:\n", indent)
+
+	for _, decoder := range decoders {
+		decoded, err := decoder.DecodeEvent(ev)
+		if err != nil {
+			continue
+		}
+		if decoded != nil {
+			prettyPrintStruct(indent+"  ", ev.Value, decoded)
+			return
+		}
+	}
+
+	prettyPrintCBOR(indent+"  ", ev.Value)
+}

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -24,8 +24,11 @@ func init() {
 
 	nodeStatusCmd.Flags().AddFlagSet(common.SelectorFlags)
 
+	blockCmd.Flags().AddFlagSet(common.SelectorFlags)
+
 	Cmd.AddCommand(governanceProposalCmd)
 	Cmd.AddCommand(runtimeStatsCmd)
 	Cmd.AddCommand(nativeTokenCmd)
 	Cmd.AddCommand(nodeStatusCmd)
+	Cmd.AddCommand(blockCmd)
 }


### PR DESCRIPTION
Example output:
```
$ oasis inspect block 429810 0
Network:        mainnet
ParaTime:       sapphire (Sapphire Mainnet)
Round:          429810
Version:        0
Namespace:      000000000000000000000000000000000000000000000000f80306c9858e7279
Timestamp:      2023-05-10T13:58:31+02:00
Type:           1
Previous:       27b533249293dbd89c201afb0e7016f374227dece392a244d2524fc0c65dd9ba
I/O root:       3aab20006fd571491f9b2ddff140a4837b6777a5cc1823cc8c00e68359db0b29
State root:     3e9d977ddb72538aa5febfaf7e8e8bdb8d02fcb555511e699cd2ffa26a802efb
Messages (out): 65f1a41bea764611d33e0374ddc927e1e1696fb282ba8b81779730b0a32dccc6
Messages (in):  c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a
Transacations:  1

=== Transaction 0 ===
Kind: oasis
Hash: e2049ba3f28e5937606048d00267a3f2adde1d3ca5f646b360ecad4767bf8801
Signer(s):
  1. Ax5Y8e9iqJv/fndH+pd6Xi+LiONEPY6DtMg0fXcDauld
     (signature: MEUCIQCzFdZUyC3dyzRrdb+CMZz6QmxM8BV4vrsf1C/G3s2KiQIgRqHdTzN1P+LWDovqhkB3cdYhFaMKsei/iPzTqz+F+MA=)
Content:
  Format: plain
  Method: consensus.Withdraw
  Body:
    To: oasis1qry5d5zxs58w9deu5ara5zaamhkzqtg99s00ls90
    Amount: 0.1 ROSE
  Authorized signer(s):
    1. Ax5Y8e9iqJv/fndH+pd6Xi+LiONEPY6DtMg0fXcDauld (secp256k1eth)
       Nonce: 71079
  Fee:
    Amount: 0.0011321 ROSE
    Gas limit: 11321
    (gas price: 0.0000001 ROSE per gas unit)

=== Result of transaction 0 ===
Status: ok
Data:
  null

=== Events emitted by transaction 0 ===
Events: 2

  --- Event 0 ---
  Module: accounts
  Code:   1
  Data:
    - transfer:
        from: oasis1qquzek9y9guk6plys32s7zvf4g2f8rvn9slu8uye
        to: oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln
        amount:
          amount: "100000000000000000"
          denomination: ""
      burn: null
      mint: null

  --- Event 1 ---
  Module: core
  Code:   1
  Data:
    - amount: 11315
```

Or for Ethereum transactions:
```
$ oasis inspect block 429809 0
Network:        mainnet
ParaTime:       sapphire (Sapphire Mainnet)
Round:          429809
Version:        0
Namespace:      000000000000000000000000000000000000000000000000f80306c9858e7279
Timestamp:      2023-05-10T13:57:27+02:00
Type:           1
Previous:       72b9184af6f7c3e9760df2b332e3faf28bccaf65df3127c379187719bdb42805
I/O root:       084e4a1e14ef1886aa92c5affb57014487c6cd0538573f6030ee10877e4c5529
State root:     e3b4e31328d7148b47281ebd46ab005c503e714f281c73b0594e229522ca730d
Messages (out): c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a
Messages (in):  c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a
Transacations:  1

=== Transaction 0 ===
Kind:      evm.ethereum.v0
Hash:      cfe71943945165c9505bc55d6dd9ce41fecacf17b4bccb13d1d11de6d02147c1
Eth hash:  0x1eb0af040d468a861807796a7a7577770619142dd01857d5b1625efb0decbf2d
Chain ID:  23294
Nonce:     67196
Type:      0
To:        0xCCD706B1c30d1c6F46F74885C3B13e3Ea28ce8AF
Value:     100000001683719844
Gas limit: 30000
Gas price: 100000000000
Data:
  (none)

=== Result of transaction 0 ===
Status: ok
Data:
  []

=== Events emitted by transaction 0 ===
Events: 1

  --- Event 0 ---
  Module: core
  Code:   1
  Data:
    - amount: 22143
```