### PR TITLE
Add sr25519 support

### DIFF
--- a/wallet/file/file.go
+++ b/wallet/file/file.go
@@ -20,10 +20,10 @@ import (
 	"github.com/oasisprotocol/deoxysii"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/sakg"
 	coreSignature "github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
-
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/ed25519"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/secp256k1"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/sr25519"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/cli/config"
@@ -45,14 +45,14 @@ const (
 // SupportedAlgorithmsForImport returns the algorithms supported by the given import kind.
 func SupportedAlgorithmsForImport(kind *wallet.ImportKind) []string {
 	if kind == nil {
-		return []string{wallet.AlgorithmEd25519Adr8, wallet.AlgorithmEd25519Raw, wallet.AlgorithmSecp256k1Bip44, wallet.AlgorithmSecp256k1Raw}
+		return []string{wallet.AlgorithmEd25519Adr8, wallet.AlgorithmEd25519Raw, wallet.AlgorithmSecp256k1Bip44, wallet.AlgorithmSecp256k1Raw, wallet.AlgorithmSr25519Adr8, wallet.AlgorithmSr25519Raw}
 	}
 
 	switch *kind {
 	case wallet.ImportKindMnemonic:
-		return []string{wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44}
+		return []string{wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44, wallet.AlgorithmSr25519Adr8}
 	case wallet.ImportKindPrivateKey:
-		return []string{wallet.AlgorithmEd25519Raw, wallet.AlgorithmSecp256k1Raw}
+		return []string{wallet.AlgorithmEd25519Raw, wallet.AlgorithmSecp256k1Raw, wallet.AlgorithmSr25519Raw}
 	default:
 		return []string{}
 	}
@@ -192,7 +192,7 @@ func (af *fileAccountFactory) PrettyKind(rawCfg map[string]interface{}) string {
 	// In case of ADR8 or BIP44 show the keypair number.
 	var number string
 	switch cfg.Algorithm {
-	case wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44:
+	case wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44, wallet.AlgorithmSr25519Adr8:
 		number = fmt.Sprintf(":%d", cfg.Number)
 	}
 	return fmt.Sprintf("%s (%s%s)", Kind, cfg.Algorithm, number)
@@ -258,6 +258,8 @@ func (af *fileAccountFactory) DataPrompt(kind wallet.ImportKind, rawCfg map[stri
 			return &survey.Multiline{Message: "Private key (base64-encoded):"}
 		case wallet.AlgorithmSecp256k1Raw:
 			return &survey.Multiline{Message: "Private key (hex-encoded):"}
+		case wallet.AlgorithmSr25519Raw:
+			return &survey.Multiline{Message: "Private key (base64-encoded):"}
 		default:
 			return nil
 		}
@@ -287,6 +289,12 @@ func (af *fileAccountFactory) DataValidator(kind wallet.ImportKind, rawCfg map[s
 				_, err := hex.DecodeString(ans.(string))
 				if err != nil {
 					return fmt.Errorf("private key must be hex-encoded (without leading 0x): %w", err)
+				}
+			case wallet.AlgorithmSr25519Raw:
+				// Ensure the private key is base64 encoded.
+				_, err := base64.StdEncoding.DecodeString(ans.(string))
+				if err != nil {
+					return fmt.Errorf("private key must be base64-encoded: %w", err)
 				}
 			default:
 				return fmt.Errorf("unsupported algorithm for %s: %s", wallet.ImportKindPrivateKey, cfg.Algorithm)
@@ -421,13 +429,13 @@ func (af *fileAccountFactory) Import(name string, passphrase string, rawCfg map[
 	switch src.Kind {
 	case wallet.ImportKindMnemonic:
 		switch cfg.Algorithm {
-		case wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44:
+		case wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44, wallet.AlgorithmSr25519Adr8:
 		default:
 			return nil, fmt.Errorf("algorithm '%s' does not support import from mnemonic", cfg.Algorithm)
 		}
 	case wallet.ImportKindPrivateKey:
 		switch cfg.Algorithm {
-		case wallet.AlgorithmEd25519Raw, wallet.AlgorithmSecp256k1Raw:
+		case wallet.AlgorithmEd25519Raw, wallet.AlgorithmSecp256k1Raw, wallet.AlgorithmSr25519Raw:
 		default:
 			return nil, fmt.Errorf("algorithm '%s' does not support import from private key", cfg.Algorithm)
 		}
@@ -517,6 +525,34 @@ func newAccount(state *secretState, cfg *accountConfig) (wallet.Account, error) 
 			state:  state,
 			signer: signer,
 		}, nil
+	case wallet.AlgorithmSr25519Adr8:
+		// For Sr25519 use the ADR 0008 derivation scheme.
+		signer, err := Sr25519FromMnemonic(state.Data, cfg.Number)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize signer: %w", err)
+		}
+
+		return &fileAccount{
+			cfg:    cfg,
+			state:  state,
+			signer: signer,
+		}, nil
+	case wallet.AlgorithmSr25519Raw:
+		// For Sr25519-Raw use the raw private key.
+		dataRaw, err := base64.StdEncoding.DecodeString(state.Data)
+		if err != nil {
+			return nil, err
+		}
+		signer, err := sr25519.NewSigner(dataRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		return &fileAccount{
+			cfg:    cfg,
+			state:  state,
+			signer: signer,
+		}, nil
 	default:
 		return nil, fmt.Errorf("algorithm '%s' not supported", state.Algorithm)
 	}
@@ -561,6 +597,8 @@ func (a *fileAccount) SignatureAddressSpec() types.SignatureAddressSpec {
 		return types.NewSignatureAddressSpecEd25519(a.Signer().Public().(ed25519.PublicKey))
 	case wallet.AlgorithmSecp256k1Bip44, wallet.AlgorithmSecp256k1Raw:
 		return types.NewSignatureAddressSpecSecp256k1Eth(a.Signer().Public().(secp256k1.PublicKey))
+	case wallet.AlgorithmSr25519Adr8, wallet.AlgorithmSr25519Raw:
+		return types.NewSignatureAddressSpecSr25519(a.Signer().Public().(sr25519.PublicKey))
 	default:
 		return types.SignatureAddressSpec{}
 	}
@@ -572,7 +610,7 @@ func (a *fileAccount) UnsafeExport() string {
 
 func init() {
 	flags := flag.NewFlagSet("", flag.ContinueOnError)
-	flags.String(cfgAlgorithm, wallet.AlgorithmEd25519Adr8, fmt.Sprintf("Cryptographic algorithm to use for this account [%s, %s]", wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44))
+	flags.String(cfgAlgorithm, wallet.AlgorithmEd25519Adr8, fmt.Sprintf("Cryptographic algorithm to use for this account [%s, %s, %s]", wallet.AlgorithmEd25519Adr8, wallet.AlgorithmSecp256k1Bip44, wallet.AlgorithmSr25519Adr8))
 	flags.Uint32(cfgNumber, 0, "Key number to use in the key derivation scheme")
 
 	wallet.Register(&fileAccountFactory{

--- a/wallet/file/sr25519.go
+++ b/wallet/file/sr25519.go
@@ -1,0 +1,53 @@
+package file
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/sakg"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/slip10"
+	sdkSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/sr25519"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// Sr25519FromMnemonic derives a signer using ADR-8 from given mnemonic.
+func Sr25519FromMnemonic(mnemonic string, number uint32) (sdkSignature.Signer, error) {
+	if number > sakg.MaxAccountKeyNumber {
+		return nil, fmt.Errorf(
+			"sakg: invalid key number: %d (maximum: %d)",
+			number,
+			sakg.MaxAccountKeyNumber,
+		)
+	}
+
+	if !bip39.IsMnemonicValid(mnemonic) {
+		return nil, fmt.Errorf("sakg: invalid mnemonic")
+	}
+
+	seed := bip39.NewSeed(mnemonic, "")
+
+	signer, chainCode, err := slip10.NewMasterKey(seed)
+	if err != nil {
+		return nil, fmt.Errorf("sakg: error deriving master key: %w", err)
+	}
+
+	pathStr := fmt.Sprintf("%s/%d'", sakg.BIP32PathPrefix, number)
+	path, err := sakg.NewBIP32Path(pathStr)
+	if err != nil {
+		return nil, fmt.Errorf("sakg: error creating BIP-0032 path %s: %w", pathStr, err)
+	}
+
+	for _, index := range path {
+		signer, chainCode, err = slip10.NewChildKey(signer, chainCode, index)
+		if err != nil {
+			return nil, fmt.Errorf("sakg: error deriving child key: %w", err)
+		}
+	}
+
+	sr25519signer, err := sr25519.NewSigner(signer.(signature.UnsafeSigner).UnsafeBytes())
+	if err != nil {
+		return nil, err
+	}
+	return sr25519signer, nil
+}

--- a/wallet/file/sr25519.go
+++ b/wallet/file/sr25519.go
@@ -1,14 +1,20 @@
 package file
 
 import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/binary"
 	"fmt"
 
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/sakg"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature/signers/memory"
+	"github.com/tyler-smith/go-bip39"
+
+	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/sakg"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/slip10"
 	sdkSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/sr25519"
-	"github.com/tyler-smith/go-bip39"
+	sdkSr25519 "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/sr25519"
 )
 
 // Sr25519FromMnemonic derives a signer using ADR-8 from given mnemonic.
@@ -27,7 +33,7 @@ func Sr25519FromMnemonic(mnemonic string, number uint32) (sdkSignature.Signer, e
 
 	seed := bip39.NewSeed(mnemonic, "")
 
-	signer, chainCode, err := slip10.NewMasterKey(seed)
+	_, chainCode, skBinary, err := newMasterKey(seed)
 	if err != nil {
 		return nil, fmt.Errorf("sakg: error deriving master key: %w", err)
 	}
@@ -38,16 +44,96 @@ func Sr25519FromMnemonic(mnemonic string, number uint32) (sdkSignature.Signer, e
 		return nil, fmt.Errorf("sakg: error creating BIP-0032 path %s: %w", pathStr, err)
 	}
 
+	var signer sdkSignature.Signer
 	for _, index := range path {
-		signer, chainCode, err = slip10.NewChildKey(signer, chainCode, index)
+		signer, chainCode, skBinary, err = newChildKey(skBinary, chainCode, index)
 		if err != nil {
 			return nil, fmt.Errorf("sakg: error deriving child key: %w", err)
 		}
 	}
 
-	sr25519signer, err := sr25519.NewSigner(signer.(signature.UnsafeSigner).UnsafeBytes())
-	if err != nil {
-		return nil, err
+	return signer, nil
+}
+
+func newMasterKey(seed []byte) (sdkSignature.Signer, slip10.ChainCode, []byte, error) {
+	// Let S be a seed byte sequence of 128 to 512 bits in length.
+	if sLen := len(seed); sLen < slip10.SeedMinSize || sLen > slip10.SeedMaxSize {
+		return nil, slip10.ChainCode{}, nil, fmt.Errorf("slip10: invalid seed")
 	}
-	return sr25519signer, nil
+
+	// 1. Calculate I = HMAC-SHA512(Key = Curve, Data = S)
+	mac := hmac.New(sha512.New, []byte("ed25519 seed"))
+	_, _ = mac.Write(seed)
+	I := mac.Sum(nil)
+
+	// 2. Split I into two 32-byte sequences, IL and IR.
+	// 3. Use parse256(IL) as master secret key, and IR as master chain code.
+	return splitDigest(I)
+}
+
+func newChildKey(kPar []byte, cPar slip10.ChainCode, index uint32) (sdkSignature.Signer, slip10.ChainCode, []byte, error) {
+	if len(kPar) < memory.SeedSize {
+		return nil, slip10.ChainCode{}, nil, fmt.Errorf("slip10: invalid parent key")
+	}
+
+	// 1. Check whether i >= 2^31 (whether the child is a hardened key).
+	if index < 1<<31 {
+		// If not (normal child):
+		// If curve is ed25519: return failure.
+		return nil, slip10.ChainCode{}, nil, fmt.Errorf("slip10: non-hardened keys not supported")
+	}
+
+	// If so (hardened child):
+	// let I = HMAC-SHA512(Key = cpar, Data = 0x00 || ser256(kpar) || ser32(i)).
+	// (Note: The 0x00 pads the private key to make it 33 bytes long.)
+	var b [4]byte
+	mac := hmac.New(sha512.New, cPar[:])
+	_, _ = mac.Write(b[0:1])                 // 0x00
+	_, _ = mac.Write(kPar[:memory.SeedSize]) // ser256(kPar)
+	binary.BigEndian.PutUint32(b[:], index)  // Note: The spec neglects to define ser32.
+	_, _ = mac.Write(b[:])                   // ser32(i)
+	I := mac.Sum(nil)
+
+	// 2. Split I into two 32-byte sequences, IL and IR.
+	// 3. The returned chain code ci is IR.
+	// 4. If curve is ed25519: The returned child key ki is parse256(IL).
+	return splitDigest(I)
+}
+
+func splitDigest(digest []byte) (sdkSignature.Signer, slip10.ChainCode, []byte, error) {
+	IL, IR := digest[:32], digest[32:]
+
+	var chainCode slip10.ChainCode
+
+	msk, err := sr25519.NewMiniSecretKeyFromBytes(IL)
+	if err != nil {
+		return nil, chainCode, nil, err
+	}
+	sk := msk.ExpandEd25519()
+	signer := sdkSr25519.NewSignerFromKeyPair(sk.KeyPair())
+	copy(chainCode[:], IR)
+
+	skBinary, err := sk.MarshalBinary()
+	if err != nil {
+		return nil, chainCode, nil, err
+	}
+
+	return signer, chainCode, skBinary, nil
+}
+
+func splitDigestOrig(digest []byte) (sdkSignature.Signer, slip10.ChainCode, []byte, error) {
+	IL, IR := digest[:32], digest[32:]
+
+	var chainCode slip10.ChainCode
+	signer, err := memory.NewFromSeed(IL)
+	if err != nil {
+		return nil, chainCode, nil, err
+	}
+	copy(chainCode[:], IR)
+
+	sr25519signer, err := sdkSr25519.NewSigner(signer.(signature.UnsafeSigner).UnsafeBytes())
+	if err != nil {
+		return nil, chainCode, nil, err
+	}
+	return sr25519signer, chainCode, signer.(signature.UnsafeSigner).UnsafeBytes(), nil
 }

--- a/wallet/ledger/signer.go
+++ b/wallet/ledger/signer.go
@@ -58,6 +58,8 @@ func (ls *ledgerSigner) ContextSign(metadata signature.Context, message []byte) 
 		return ls.dev.SignRtEd25519(ls.path, metadata, message)
 	case wallet.AlgorithmSecp256k1Bip44:
 		return ls.dev.SignRtSecp256k1(ls.path, metadata, message)
+	case wallet.AlgorithmSr25519Adr8:
+		return ls.dev.SignRtSr25519(ls.path, metadata, message)
 	}
 
 	return nil, fmt.Errorf("ledger: algorithm %s not supported", ls.algorithm)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -16,7 +16,7 @@ import (
 var registeredFactories sync.Map
 
 const (
-	// AlgorithmEd25519Adr8 is the Ed25519 algorithm using the ADR-8 derivation path (ROSE coin type).
+	// AlgorithmEd25519Adr8 is the Ed25519 algorithm using the ADR-8 derivation path.
 	AlgorithmEd25519Adr8 = "ed25519-adr8"
 	// AlgorithmEd25519Raw is the Ed25519 algorithm using raw private keys.
 	AlgorithmEd25519Raw = "ed25519-raw"
@@ -26,6 +26,10 @@ const (
 	AlgorithmSecp256k1Bip44 = "secp256k1-bip44"
 	// AlgorithmSecp256k1Raw is the Secp256k1 algorithm using raw private keys.
 	AlgorithmSecp256k1Raw = "secp256k1-raw"
+	// AlgorithmSr25519Adr8 is the Sr25519 algorithm using the ADR-8 derivation path.
+	AlgorithmSr25519Adr8 = "sr25519-adr8"
+	// AlgorithmSr25519Raw is the Sr25519 algorithm using raw private keys.
+	AlgorithmSr25519Raw = "sr25519-raw"
 )
 
 // Factory is a factory that supports accounts of a specific kind.


### PR DESCRIPTION
Implements #35:
- adds support for importing Ledger sr25519-adr8 accounts and signing ParaTime transactions
- adds support for importing sr25519-raw keys and signing ParaTime transactions
- adds support for creating and importnig sr25519-adr8 file-based mnemonics