### PR TITLE
fix(cmd): Oasis paratime statistics fixes

### DIFF
--- a/cmd/paratime/statistics.go
+++ b/cmd/paratime/statistics.go
@@ -101,8 +101,11 @@ type entityStats struct {
 }
 
 var statsCmd = &cobra.Command{
-	Use:     "statistics [<start-height> [<end-height>]]",
-	Short:   "Show ParaTime statistics",
+	Use:   "statistics [<start-height> [<end-height>]]",
+	Short: "Show ParaTime statistics",
+	Long: "Show ParaTime statistics between start-height and end-height round of blocks." +
+		"\nIf negative start-height is passed, it will show statistics for the last given blocks." +
+		"\nIf 0 start-height passed, it will generate statistics from the oldest block available to the endpoint.",
 	Aliases: []string{"stats"},
 	Args:    cobra.MaximumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -115,7 +118,7 @@ var statsCmd = &cobra.Command{
 
 		// Parse command line arguments
 		var (
-			startHeightArg int64
+			startHeightArg int64 = -1
 			endHeight      uint64
 		)
 		if argLen := len(args); argLen > 0 {
@@ -166,12 +169,15 @@ var statsCmd = &cobra.Command{
 		cobra.CheckErr(err)
 		signature.SetChainContext(chainCtx)
 
-		fmt.Printf(
-			"gathering statistics: runtime-id: %s, start-height: %d, end-height: %d\n",
-			runtimeID,
-			startHeight,
-			endHeight,
-		)
+		fmt.Println("=== PARATIME STATISTICS ===")
+		fmt.Printf("%-26s %s", "Network:", npa.PrettyPrintNetwork())
+		fmt.Println()
+		fmt.Printf("%-26s %s", "ParaTime ID:", runtimeID)
+		fmt.Println()
+		fmt.Printf("%-26s %8d", "Start height:", startHeight)
+		fmt.Println()
+		fmt.Printf("%-26s %8d", "End height:", endHeight)
+		fmt.Println()
 
 		// Do the actual work
 		stats := &runtimeStats{
@@ -539,14 +545,22 @@ func (s *runtimeStats) prepareEntitiesOutput(
 }
 
 func (s *runtimeStats) printStats() {
-	fmt.Printf("ParaTime rounds: %d\n", s.rounds)
-	fmt.Printf("Successful rounds: %d\n", s.successfulRounds)
-	fmt.Printf("Epoch transition rounds: %d\n", s.epochTransitionRounds)
-	fmt.Printf("Proposer timeouted rounds: %d\n", s.proposerTimeoutedRounds)
-	fmt.Printf("Failed rounds: %d\n", s.failedRounds)
-	fmt.Printf("Discrepancies: %d\n", s.discrepancyDetected)
-	fmt.Printf("Discrepancies (timeout): %d\n", s.discrepancyDetectedTimeout)
-	fmt.Printf("Suspended: %d\n", s.suspendedRounds)
+	fmt.Printf("%-26s %d", "ParaTime rounds:", s.rounds)
+	fmt.Println()
+	fmt.Printf("%-26s %d", "Successful rounds:", s.successfulRounds)
+	fmt.Println()
+	fmt.Printf("%-26s %d", "Epoch transition rounds:", s.epochTransitionRounds)
+	fmt.Println()
+	fmt.Printf("%-26s %d", "Proposer timed out rounds:", s.proposerTimeoutedRounds)
+	fmt.Println()
+	fmt.Printf("%-26s %d", "Failed rounds:", s.failedRounds)
+	fmt.Println()
+	fmt.Printf("%-26s %d", "Discrepancies:", s.discrepancyDetected)
+	fmt.Println()
+	fmt.Printf("%-26s %d", "Discrepancies (timeout):", s.discrepancyDetectedTimeout)
+	fmt.Println()
+	fmt.Printf("%-26s %d", "Suspended:", s.suspendedRounds)
+	fmt.Println()
 
 	fmt.Println("\n=== ENTITY STATISTICS ===")
 	table := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
This PR:
- defaults to `-1` for start-block since taking the last retained block will timeout on public endpoints. You can explicitly set start-height to `0`, if you want to pick the last retained block as a start block. Adds long description mentioning this.
- replaces `--write-csv` and `--file-csv` with more standard `-o` or `--output-file`. If no output file provided, the result is printed on screen. If output file provided, the entity statistics is written only into file.
- cosmetic UI fixes (padding, ParaTime terms, cross-OS newlines etc.)