### PR TITLE
fix(account): Fix crash when using Ledger secp256k1 on consensus

### DIFF
--- a/wallet/ledger/ledger.go
+++ b/wallet/ledger/ledger.go
@@ -236,7 +236,12 @@ func newAccount(cfg *accountConfig) (wallet.Account, error) {
 }
 
 func (a *ledgerAccount) ConsensusSigner() coreSignature.Signer {
-	return a.coreSigner
+	switch a.cfg.Algorithm {
+	case wallet.AlgorithmEd25519Adr8, wallet.AlgorithmEd25519Legacy:
+		return a.coreSigner
+	}
+
+	return nil
 }
 
 func (a *ledgerAccount) Signer() signature.Signer {


### PR DESCRIPTION
Suppose:

```
$ oasis wallet ls
ACCOUNT         KIND                            ADDRESS                                        
lenny           ledger (secp256k1-bip44:3)      oasis1qrmw4rhvp8ksj3yx6p2ftnkz864muc3re5jlgall
oscar (*)       file (ed25519-adr8:0)           oasis1qp87hflmelnpqhzcqcw8rhzakq4elj7jzv090p3e
```

Before:
```
$ oasis account transfer 2.5 oscar --account lenny --no-paratime
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xe0f34c]

goroutine 1 [running]:
github.com/oasisprotocol/cli/wallet/ledger.(*ledgerCoreSigner).Public(0x48d7e5?)
        /home/oa/cli/wallet/ledger/signer.go:19 +0xc
github.com/oasisprotocol/cli/cmd/common.SignConsensusTransaction({0x1407dd0, 0xc000138000}, 0xc000151c20, {0x140b718, 0xc00037a390}, {0x1406020, 0xc000128190}, 0xc000428280)
        /home/oa/cli/cmd/common/transaction.go:141 +0x39c
github.com/oasisprotocol/cli/cmd/account.glob..func11(0x1ab4800?, {0xc000150550, 0x2, 0x5?})
        /home/oa/cli/cmd/account/transfer.go:70 +0x605
github.com/spf13/cobra.(*Command).execute(0x1ab4800, {0xc000150500, 0x5, 0x5})
        /home/oa/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0x1ab05e0)
        /home/oa/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /home/oa/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/oasisprotocol/cli/cmd.Execute(...)
        /home/oa/cli/cmd/root.go:34
main.main()
        /home/oa/cli/main.go:6 +0x25
```

After:

```
$ oasis account transfer 2.5 oscar --account lenny --no-paratime
Error: account does not support signing consensus transactions
```