### PR TITLE
Add macOS releases

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,9 +17,12 @@ on:
 
 jobs:
   tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     # NOTE: This name appears in GitHub's Checks API.
-    name: tests
-    runs-on: ubuntu-latest
+    name: tests-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,10 @@ before:
   hooks:
     - go mod tidy
 
+universal_binaries:
+  - replace: true
+    name_template: oasis
+
 builds:
   - binary: oasis
     flags:
@@ -11,10 +15,10 @@ builds:
     ldflags:
       - -buildid=
       - "{{.Env.GOLDFLAGS_VERSION}}"
-    goos:
-      - linux
-    goarch:
-      - amd64
+    targets:
+      - linux_amd64
+      - darwin_amd64
+      - darwin_arm64
 
 archives:
   - name_template: "{{replace .ProjectName \" \" \"_\" | tolower}}_{{.Version}}_{{.Os}}_{{.Arch}}"

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ all: build
 
 # Build.
 build:
-	@$(ECHO) "$(MAGENTA)*** Building Go code...$(OFF)"
+	@$(PRINT) "$(MAGENTA)*** Building Go code...$(OFF)\n"
 	@$(GO) build -v -o oasis $(GOFLAGS) $(GO_EXTRA_FLAGS)
 
 # Format code.
 fmt:
-	@$(ECHO) "$(CYAN)*** Running Go formatters...$(OFF)"
+	@$(PRINT) "$(CYAN)*** Running Go formatters...$(OFF)"
 	@gofumpt -w .
 	@goimports -w -local github.com/oasisprotocol/cli .
 
@@ -23,19 +23,19 @@ fmt:
 lint-targets := lint-go lint-docs lint-git lint-go-mod-tidy
 
 lint-go:
-	@$(ECHO) "$(CYAN)*** Running Go linters...$(OFF)"
+	@$(PRINT) "$(CYAN)*** Running Go linters...$(OFF)"
 	@env -u GOPATH golangci-lint run --verbose
 
 lint-git:
-	@$(ECHO) "$(CYAN)*** Running gitlint...$(OFF)"
+	@$(PRINT) "$(CYAN)*** Running gitlint...$(OFF)"
 	@$(CHECK_GITLINT)
 
 lint-docs:
-	@$(ECHO) "$(CYAN)*** Running markdownlint-cli...$(OFF)"
+	@$(PRINT) "$(CYAN)*** Running markdownlint-cli...$(OFF)"
 	@npx --yes markdownlint-cli '**/*.md'
 
 lint-go-mod-tidy:
-	@$(ECHO) "$(CYAN)*** Checking go mod tidy...$(OFF)"
+	@$(PRINT) "$(CYAN)*** Checking go mod tidy...$(OFF)"
 	@$(ENSURE_GIT_CLEAN)
 	@$(CHECK_GO_MOD_TIDY)
 
@@ -49,14 +49,14 @@ release-build:
 test-targets := test-unit
 
 test-unit:
-	@$(ECHO) "$(CYAN)*** Running unit tests...$(OFF)"
+	@$(PRINT) "$(CYAN)*** Running unit tests...$(OFF)"
 	@$(GO) test -v -race ./...
 
 test: $(test-targets)
 
 # Clean.
 clean:
-	@$(ECHO) "$(CYAN)*** Cleaning up ...$(OFF)"
+	@$(PRINT) "$(CYAN)*** Cleaning up ...$(OFF)"
 	@$(GO) clean -x
 	rm -f oasis
 	$(GO) clean -testcache

--- a/common.mk
+++ b/common.mk
@@ -10,17 +10,15 @@ ifdef ISATTY
 	RED := \e[0;31m
 	OFF := \e[0m
 	# Use external echo command since the built-in echo doesn't support '-e'.
-	ECHO_CMD := /bin/echo -e
 else
 	MAGENTA := ""
 	CYAN := ""
 	RED := ""
 	OFF := ""
-	ECHO_CMD := echo
 endif
 
 # Output messages to stderr instead stdout.
-ECHO := $(ECHO_CMD) 1>&2
+PRINT := printf 1>&2
 
 # Name of git remote pointing to the canonical upstream git repository, i.e.
 # git@github.com:oasisprotocol/cli.git.
@@ -67,7 +65,7 @@ export GOLDFLAGS ?= "$(GOLDFLAGS_VERSION)"
 # Helper that ensures the git workspace is clean.
 define ENSURE_GIT_CLEAN =
 	if [[ ! -z `git status --porcelain` ]]; then \
-		$(ECHO) "$(RED)Error: Git workspace is dirty.$(OFF)"; \
+		$(PRINT) "$(RED)Error: Git workspace is dirty.$(OFF)\n"; \
 		exit 1; \
 	fi
 endef
@@ -78,7 +76,7 @@ endef
 define CHECK_GO_MOD_TIDY =
     $(GO) mod tidy; \
     if [[ ! -z `git status --porcelain go.mod go.sum` ]]; then \
-        $(ECHO) "$(RED)Error: The following changes detected after running 'go mod tidy':$(OFF)"; \
+        $(PRINT) "$(RED)Error: The following changes detected after running 'go mod tidy':$(OFF)\n"; \
         git diff go.mod go.sum; \
         exit 1; \
     fi
@@ -91,6 +89,6 @@ endef
 define CHECK_GITLINT =
 	BRANCH=$(OASIS_CLI_GIT_ORIGIN_REMOTE)/$(RELEASE_BRANCH); \
 	COMMIT_SHA=`git rev-parse $$BRANCH` && \
-	$(ECHO) "$(CYAN)*** Running gitlint for commits from $$BRANCH ($${COMMIT_SHA:0:7})... $(OFF)"; \
+	$(PRINT) "$(CYAN)*** Running gitlint for commits from $$BRANCH ($${COMMIT_SHA:0:7})... $(OFF)\n"; \
 	gitlint --commits $$BRANCH..HEAD
 endef


### PR DESCRIPTION
This also changes the way makefiles print colorized output, similar to what was done in oasisprotocol/deoxysii-rust#22, for better compatibility with macOS.

macOS releases are universal binaries that work on either architecture, with whatever is the minimum supported system version for the go compiler (High Sierra on Intel, Big Sur on Apple silicon).