### PR TITLE
fix(cmd/paratime): Don't crash when pretty-printing CBOR NULL

### DIFF
--- a/cmd/paratime/show.go
+++ b/cmd/paratime/show.go
@@ -241,6 +241,8 @@ func convertPrettyStruct(in interface{}) (interface{}, error) {
 	}
 
 	switch v.Kind() {
+	case reflect.Invalid:
+		return nil, nil
 	case reflect.Slice:
 		// Walk slices.
 		if v.Type().Elem().Kind() == reflect.Uint8 {


### PR DESCRIPTION
Fixes #98 