### PR TITLE
Sr25519 support for Ledger

### DIFF
--- a/wallet/ledger/signer.go
+++ b/wallet/ledger/signer.go
@@ -58,6 +58,8 @@ func (ls *ledgerSigner) ContextSign(metadata signature.Context, message []byte) 
 		return ls.dev.SignRtEd25519(ls.path, metadata, message)
 	case wallet.AlgorithmSecp256k1Bip44:
 		return ls.dev.SignRtSecp256k1(ls.path, metadata, message)
+	case wallet.AlgorithmSr25519Adr8:
+		return ls.dev.SignRtSr25519(ls.path, metadata, message)
 	}
 
 	return nil, fmt.Errorf("ledger: algorithm %s not supported", ls.algorithm)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -16,7 +16,7 @@ import (
 var registeredFactories sync.Map
 
 const (
-	// AlgorithmEd25519Adr8 is the Ed25519 algorithm using the ADR-8 derivation path (ROSE coin type).
+	// AlgorithmEd25519Adr8 is the Ed25519 algorithm using the ADR-8 derivation path.
 	AlgorithmEd25519Adr8 = "ed25519-adr8"
 	// AlgorithmEd25519Raw is the Ed25519 algorithm using raw private keys.
 	AlgorithmEd25519Raw = "ed25519-raw"
@@ -26,6 +26,10 @@ const (
 	AlgorithmSecp256k1Bip44 = "secp256k1-bip44"
 	// AlgorithmSecp256k1Raw is the Secp256k1 algorithm using raw private keys.
 	AlgorithmSecp256k1Raw = "secp256k1-raw"
+	// AlgorithmSr25519Adr8 is the Sr25519 algorithm using the Ledger-compatible derivation path defined in ADR-8.
+	AlgorithmSr25519Adr8 = "sr25519-adr8"
+	// AlgorithmSr25519Raw is the Sr25519 algorithm using raw private keys.
+	AlgorithmSr25519Raw = "sr25519-raw"
 )
 
 // Factory is a factory that supports accounts of a specific kind.


### PR DESCRIPTION
Implements #35:
- adds support for importing Ledger Sr25519 accounts (see https://github.com/oasisprotocol/adrs/blob/main/0014-runtime-signing-tx-with-hardware-wallet.md) and signing ParaTime transactions
- adds support for importing Sr25519 raw keys and signing ParaTime transactions