### PR TITLE
Sort network gas costs by its kind

### DIFF
--- a/cmd/network/show.go
+++ b/cmd/network/show.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	consensusPretty "github.com/oasisprotocol/oasis-core/go/common/prettyprint"
+	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
@@ -182,8 +184,15 @@ var showCmd = &cobra.Command{
 
 				fmt.Printf("Gas costs for network %s:", npa.PrettyPrintNetwork())
 				fmt.Println()
-				for kind, cost := range consensusParams.GasCosts {
-					fmt.Printf("  - %-26s %d", kind+":", cost)
+
+				// Print costs ordered by kind.
+				kinds := make([]string, 0, len(consensusParams.GasCosts))
+				for k := range consensusParams.GasCosts {
+					kinds = append(kinds, string(k))
+				}
+				sort.Strings(kinds)
+				for _, k := range kinds {
+					fmt.Printf("  - %-26s %d", k+":", consensusParams.GasCosts[transaction.Op(k)])
 					fmt.Println()
 				}
 				return


### PR DESCRIPTION
This enables reproducibility in the tests.

Example:

```
$ oasis network show gas-costs
Gas costs for network mainnet:
  - add_escrow:                1000
  - allow:                     1000
  - amend_commission_schedule: 1000
  - burn:                      1000
  - reclaim_escrow:            1000
  - transfer:                  1000
  - withdraw:                  1000
```