### PR TITLE
fix(wallet/ledger): Derivation of sr25519 addresses

### DIFF
--- a/examples/account/amend-commission-schedule.y.in
+++ b/examples/account/amend-commission-schedule.y.in
@@ -1,1 +1,1 @@
-oasis account amend-commission-schedule --bounds 29000/1000/2000,35000/900/1900 --rates 29000/1500
+oasis account amend-commission-schedule --bounds 329000/1000/2000,335000/900/1900 --rates 329000/1500

--- a/examples/account/amend-commission-schedule.y.out
+++ b/examples/account/amend-commission-schedule.y.out
@@ -3,19 +3,19 @@ Method: staking.AmendCommissionSchedule
 Body:
   Amendment:
     Rates:
-      (1) start: epoch 29000
+      (1) start: epoch 329000
           rate:  1.5%
     Rate Bounds:
-      (1) start:        epoch 29000
+      (1) start:        epoch 329000
           minimum rate: 1.0%
           maximum rate: 2.0%
-      (2) start:        epoch 35000
+      (2) start:        epoch 335000
           minimum rate: 0.9%
           maximum rate: 1.9%
 Nonce:  1
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1355
+  Gas limit: 1361
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/delegate-paratime.y.out
+++ b/examples/account/delegate-paratime.y.out
@@ -8,8 +8,8 @@ Authorized signer(s):
   1. Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8= (ed25519)
      Nonce: 0
 Fee:
-  Amount: 0.0011312 TEST
-  Gas limit: 11312
+  Amount: 0.0061312 TEST
+  Gas limit: 61312
   (gas price: 0.0000001 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/deposit-eth.y.out
+++ b/examples/account/deposit-eth.y.out
@@ -9,7 +9,7 @@ Authorized signer(s):
      Nonce: 0
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 11310
+  Gas limit: 61310
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/deposit-named.y.out
+++ b/examples/account/deposit-named.y.out
@@ -9,7 +9,7 @@ Authorized signer(s):
      Nonce: 0
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 11310
+  Gas limit: 61310
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/deposit-oasis.y.out
+++ b/examples/account/deposit-oasis.y.out
@@ -9,7 +9,7 @@ Authorized signer(s):
      Nonce: 0
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 11310
+  Gas limit: 61310
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/deposit.y.out
+++ b/examples/account/deposit.y.out
@@ -9,7 +9,7 @@ Authorized signer(s):
      Nonce: 0
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 11285
+  Gas limit: 61285
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/undelegate-paratime.y.out
+++ b/examples/account/undelegate-paratime.y.out
@@ -8,8 +8,8 @@ Authorized signer(s):
   1. Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8= (ed25519)
      Nonce: 0
 Fee:
-  Amount: 0.003131 TEST
-  Gas limit: 31310
+  Amount: 0.012131 TEST
+  Gas limit: 121310
   (gas price: 0.0000001 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/withdraw-named.y.out
+++ b/examples/account/withdraw-named.y.out
@@ -8,8 +8,8 @@ Authorized signer(s):
   1. Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8= (ed25519)
      Nonce: 0
 Fee:
-  Amount: 0.0011311 TEST
-  Gas limit: 11311
+  Amount: 0.0061311 TEST
+  Gas limit: 61311
   (gas price: 0.0000001 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/withdraw-oasis.y.out
+++ b/examples/account/withdraw-oasis.y.out
@@ -8,8 +8,8 @@ Authorized signer(s):
   1. Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8= (ed25519)
      Nonce: 0
 Fee:
-  Amount: 0.0011311 TEST
-  Gas limit: 11311
+  Amount: 0.0061311 TEST
+  Gas limit: 61311
   (gas price: 0.0000001 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/withdraw.y.out
+++ b/examples/account/withdraw.y.out
@@ -8,8 +8,8 @@ Authorized signer(s):
   1. Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8= (ed25519)
      Nonce: 0
 Fee:
-  Amount: 0.0011286 TEST
-  Gas limit: 11286
+  Amount: 0.0061286 TEST
+  Gas limit: 61286
   (gas price: 0.0000001 TEST per gas unit)
 
 Network:  testnet

--- a/wallet/ledger/ledger.go
+++ b/wallet/ledger/ledger.go
@@ -186,7 +186,7 @@ func newAccount(cfg *accountConfig) (wallet.Account, error) {
 		if cfg.Algorithm == wallet.AlgorithmEd25519Legacy {
 			path = getLegacyPath(cfg.Number)
 		}
-		rawPk, err := dev.GetPublicKeyEd25519(path, false)
+		rawPk, err := dev.GetPublicKey25519(path, wallet.AlgorithmEd25519Adr8, false)
 		if err != nil {
 			_ = dev.Close()
 			return nil, err
@@ -219,7 +219,7 @@ func newAccount(cfg *accountConfig) (wallet.Account, error) {
 		pk = secp256k1pk
 	case wallet.AlgorithmSr25519Adr8:
 		path = getAdr0008Path(cfg.Number)
-		rawPk, err := dev.GetPublicKeySr25519(path, false)
+		rawPk, err := dev.GetPublicKey25519(path, wallet.AlgorithmSr25519Adr8, false)
 		if err != nil {
 			_ = dev.Close()
 			return nil, err


### PR DESCRIPTION
This PR:
- Adds new Sr25519 address derivation (in addition to Ed25519 derivation) to sanity check when obtaining the public key from the device. Noticed while testing https://github.com/Zondax/ledger-oasis/pull/206.
- Bumps examples.