### PR TITLE
cmd/wallet: More reserved addresses aliases and checks

### DIFF
--- a/cmd/account/withdraw.go
+++ b/cmd/account/withdraw.go
@@ -61,7 +61,7 @@ var withdrawCmd = &cobra.Command{
 			}
 		} else {
 			// Destination address is implicit, but obtain it for safety check below nonetheless.
-			addr, _, err := helpers.ResolveAddress(npa.Network, npa.Account.Address)
+			addr, _, err := common.ResolveAddress(npa.Network, npa.Account.Address)
 			cobra.CheckErr(err)
 			addrToCheck = addr.String()
 		}

--- a/cmd/common/selector.go
+++ b/cmd/common/selector.go
@@ -7,7 +7,6 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/helpers"
 
 	cliConfig "github.com/oasisprotocol/cli/config"
 )
@@ -80,16 +79,9 @@ func GetNPASelection(cfg *cliConfig.Config) *NPASelection {
 		s.AccountName = selectedAccount
 	}
 	if s.AccountName != "" {
-		if testName := helpers.ParseTestAccountAddress(s.AccountName); testName != "" {
-			testAcc, err := LoadTestAccountConfig(testName)
-			cobra.CheckErr(err)
-			s.Account = testAcc
-		} else {
-			s.Account = cfg.Wallet.All[s.AccountName]
-			if s.Account == nil {
-				cobra.CheckErr(fmt.Errorf("account '%s' does not exist in the wallet", s.AccountName))
-			}
-		}
+		accCfg, err := LoadAccountConfig(cfg, s.AccountName)
+		cobra.CheckErr(err)
+		s.Account = accCfg
 	}
 
 	return &s

--- a/cmd/common/wallet.go
+++ b/cmd/common/wallet.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -10,6 +11,8 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	configSdk "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/helpers"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
@@ -19,10 +22,31 @@ import (
 	"github.com/oasisprotocol/cli/wallet/test"
 )
 
+const (
+	addressExplicitSeparator = ":"
+	addressExplicitParaTime  = "paratime"
+	addressExplicitConsensus = "consensus"
+	addressExplicitPool      = "pool"
+	addressExplicitTest      = "test"
+
+	// Shared address literals.
+	poolCommon         = "common"
+	poolFeeAccumulator = "fee-accumulator"
+
+	// Consensus address literals.
+	poolGovernanceDeposits = "governance-deposits"
+	poolBurn               = "burn"
+
+	// ParaTime address literals.
+	poolRewards           = "rewards"
+	poolPendingWithdrawal = "pending-withdrawal"
+	poolPendingDelegation = "pending-delegation"
+)
+
 // LoadAccount loads the given named account.
 func LoadAccount(cfg *config.Config, name string) wallet.Account {
 	// Check if the specified account is a test account.
-	if testName := helpers.ParseTestAccountAddress(name); testName != "" {
+	if testName := ParseTestAccountAddress(name); testName != "" {
 		acc, err := LoadTestAccount(testName)
 		cobra.CheckErr(err)
 		return acc
@@ -49,9 +73,22 @@ func LoadAccount(cfg *config.Config, name string) wallet.Account {
 	return acc
 }
 
+// ParseTestAccountAddress extracts test account name from "test:some_test_account" format or
+// returns an empty string, if the format doesn't match.
+func ParseTestAccountAddress(name string) string {
+	if strings.Contains(name, addressExplicitSeparator) {
+		subs := strings.SplitN(name, addressExplicitSeparator, 2)
+		if subs[0] == addressExplicitTest {
+			return subs[1]
+		}
+	}
+
+	return ""
+}
+
 // LoadAccountConfig loads the config instance of the given named account.
 func LoadAccountConfig(cfg *config.Config, name string) (*config.Account, error) {
-	if testName := helpers.ParseTestAccountAddress(name); testName != "" {
+	if testName := ParseTestAccountAddress(name); testName != "" {
 		return LoadTestAccountConfig(testName)
 	}
 
@@ -113,7 +150,78 @@ func ResolveLocalAccountOrAddress(net *configSdk.Network, address string) (*type
 		return &addr, entry.GetEthAddress(), nil
 	}
 
-	return helpers.ResolveAddress(net, address)
+	return ResolveAddress(net, address)
+}
+
+// ResolveAddress resolves a string address into the corresponding account address.
+func ResolveAddress(net *configSdk.Network, address string) (*types.Address, *ethCommon.Address, error) {
+	if addr, ethAddr, _ := helpers.ResolveEthOrOasisAddress(address); addr != nil {
+		return addr, ethAddr, nil
+	}
+
+	if !strings.Contains(address, addressExplicitSeparator) {
+		return nil, nil, fmt.Errorf("unsupported address format")
+	}
+
+	subs := strings.SplitN(address, addressExplicitSeparator, 3)
+	switch kind, data := subs[0], subs[1]; kind {
+	case addressExplicitParaTime:
+		// paratime:sapphire, paratime:emerald, paratime:cipher
+		pt := net.ParaTimes.All[data]
+		if pt == nil {
+			return nil, nil, fmt.Errorf("paratime '%s' does not exist", data)
+		}
+
+		addr := types.NewAddressFromConsensus(staking.NewRuntimeAddress(pt.Namespace()))
+		return &addr, nil, nil
+	case addressExplicitPool:
+		// pool:paratime:pending-withdrawal, pool:paratime:fee-accumulator, pool:consensus:fee-accumulator
+		poolKind, poolName := data, ""
+		if len(subs) > 2 {
+			poolName = subs[2]
+		}
+		if poolKind == addressExplicitParaTime {
+			switch poolName {
+			case poolCommon:
+				return &accounts.CommonPoolAddress, nil, nil
+			case poolFeeAccumulator:
+				return &accounts.FeeAccumulatorAddress, nil, nil
+			case poolPendingDelegation:
+				return &consensusaccounts.PendingDelegationAddress, nil, nil
+			case poolPendingWithdrawal:
+				return &consensusaccounts.PendingWithdrawalAddress, nil, nil
+			case poolRewards:
+				return &rewards.RewardPoolAddress, nil, nil
+			default:
+				return nil, nil, fmt.Errorf("unsupported ParaTime pool: %s", poolName)
+			}
+		} else if poolKind == addressExplicitConsensus {
+			var addr types.Address
+			switch poolName {
+			case poolBurn:
+				addr = types.NewAddressFromConsensus(staking.BurnAddress)
+			case poolCommon:
+				addr = types.NewAddressFromConsensus(staking.CommonPoolAddress)
+			case poolFeeAccumulator:
+				addr = types.NewAddressFromConsensus(staking.FeeAccumulatorAddress)
+			case poolGovernanceDeposits:
+				addr = types.NewAddressFromConsensus(staking.GovernanceDepositsAddress)
+			default:
+				return nil, nil, fmt.Errorf("unsupported consensus pool: %s", poolName)
+			}
+			return &addr, nil, nil
+		}
+		return nil, nil, fmt.Errorf("unsupported pool kind: %s. Please use pool:<poolKind>:<poolName>, for example pool:paratime:pending-withdrawal", poolKind)
+	case addressExplicitTest:
+		// test:alice, test:dave
+		if testKey, ok := testing.TestAccounts[data]; ok {
+			return &testKey.Address, testKey.EthAddress, nil
+		}
+		return nil, nil, fmt.Errorf("unsupported test account: %s", data)
+	default:
+		// Unsupported kind.
+		return nil, nil, fmt.Errorf("unsupported explicit address kind: %s", kind)
+	}
 }
 
 // CheckAddressIsConsensusCapable checks whether the given address is derived from any known
@@ -150,15 +258,35 @@ func CheckAddressIsConsensusCapable(cfg *config.Config, address string) error {
 // fee accumulator or the native ParaTime addresses.
 func CheckAddressNotReserved(cfg *config.Config, address string) error {
 	if address == rewards.RewardPoolAddress.String() {
-		return fmt.Errorf("address '%s' is rewards pool address", address)
+		return fmt.Errorf("address '%s' is ParaTime rewards pool address", address)
+	}
+
+	if address == accounts.CommonPoolAddress.String() {
+		return fmt.Errorf("address '%s' is ParaTime common pool address", address)
+	}
+
+	if address == accounts.FeeAccumulatorAddress.String() {
+		return fmt.Errorf("address '%s' is ParaTime fee accumulator address", address)
+	}
+
+	if address == consensusaccounts.PendingDelegationAddress.String() {
+		return fmt.Errorf("address '%s' is ParaTime pending delegations address", address)
+	}
+
+	if address == consensusaccounts.PendingWithdrawalAddress.String() {
+		return fmt.Errorf("address '%s' is ParaTime pending withdrawal address", address)
+	}
+
+	if address == staking.BurnAddress.String() {
+		return fmt.Errorf("address '%s' is consensus burn address", address)
 	}
 
 	if address == staking.CommonPoolAddress.String() {
-		return fmt.Errorf("address '%s' is common pool address", address)
+		return fmt.Errorf("address '%s' is consensus common pool address", address)
 	}
 
 	if address == staking.FeeAccumulatorAddress.String() {
-		return fmt.Errorf("address '%s' is fee accumulator address", address)
+		return fmt.Errorf("address '%s' is consensus fee accumulator address", address)
 	}
 
 	if address == staking.GovernanceDepositsAddress.String() {

--- a/cmd/common/wallet_test.go
+++ b/cmd/common/wallet_test.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+)
+
+func TestResolveAddress(t *testing.T) {
+	require := require.New(t)
+
+	net := config.Network{
+		ParaTimes: config.ParaTimes{
+			All: map[string]*config.ParaTime{
+				"pt1": {
+					ID: "0000000000000000000000000000000000000000000000000000000000000000",
+				},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		address         string
+		expectedAddr    string
+		expectedEthAddr string
+	}{
+		{"", "", ""},
+		{"oasis1", "", ""},
+		{"oasis1blah", "", ""},
+		{"oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz", "oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz", ""},
+		{"0x", "", ""},
+		{"0xblah", "", ""},
+		{"0x60a6321eA71d37102Dbf923AAe2E08d005C4e403", "oasis1qpaqumrpewltmh9mr73hteycfzveus2rvvn8w5sp", "0x60a6321eA71d37102Dbf923AAe2E08d005C4e403"},
+		{"paratime:", "", ""},
+		{"paratime:invalid", "", ""},
+		{"paratime:pt1", "oasis1qqdn25n5a2jtet2s5amc7gmchsqqgs4j0qcg5k0t", ""},
+		{"pool:", "", ""},
+		{"pool:invalid", "", ""},
+		{"pool:paratime:common", "oasis1qz78phkdan64g040cvqvqpwkplfqf6tj6uwcsh30", ""},
+		{"pool:paratime:fee-accumulator", "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4", ""},
+		{"pool:paratime:rewards", "oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav", ""},
+		{"pool:paratime:pending-delegation", "oasis1qzcdegtf7aunxr5n5pw7n5xs3u7cmzlz9gwmq49r", ""},
+		{"pool:paratime:pending-withdrawal", "oasis1qr677rv0dcnh7ys4yanlynysvnjtk9gnsyhvm6ln", ""},
+		{"pool:consensus:burn", "oasis1qzq8u7xs328puu2jy524w3fygzs63rv3u5967970", ""},
+		{"pool:consensus:common", "oasis1qrmufhkkyyf79s5za2r8yga9gnk4t446dcy3a5zm", ""},
+		{"pool:consensus:fee-accumulator", "oasis1qqnv3peudzvekhulf8v3ht29z4cthkhy7gkxmph5", ""},
+		{"pool:consensus:governance-deposits", "oasis1qp65laz8zsa9a305wxeslpnkh9x4dv2h2qhjz0ec", ""},
+		{"test:alice", "oasis1qrec770vrek0a9a5lcrv0zvt22504k68svq7kzve", ""},
+		{"test:dave", "oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt", "0xDce075E1C39b1ae0b75D554558b6451A226ffe00"},
+		{"test:frank", "oasis1qqnf0s9p8z79zfutszt0hwlh7w7jjrfqnq997mlw", ""},
+		{"test:invalid", "", ""},
+		{"invalid:", "", ""},
+	} {
+		addr, ethAddr, err := ResolveAddress(&net, tc.address)
+		if len(tc.expectedAddr) > 0 {
+			require.NoError(err, tc.address)
+			require.EqualValues(tc.expectedAddr, addr.String(), tc.address)
+			if len(tc.expectedEthAddr) > 0 {
+				require.EqualValues(tc.expectedEthAddr, ethAddr.String())
+			}
+		} else {
+			require.Error(err, tc.address)
+		}
+	}
+}
+
+func TestParseTestAccountAddress(t *testing.T) {
+	require := require.New(t)
+
+	for _, tc := range []struct {
+		address  string
+		expected string
+	}{
+		{"test:abc", "abc"},
+		{"testabc", ""},
+		{"testing:abc", ""},
+		{"oasis1qqzh32kr72v7x55cjnjp2me0pdn579u6as38kacz", ""},
+		{"", ""},
+	} {
+		testName := ParseTestAccountAddress(tc.address)
+		require.EqualValues(tc.expected, testName, tc.address)
+	}
+}

--- a/cmd/network/show.go
+++ b/cmd/network/show.go
@@ -17,7 +17,6 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-core/go/staking/api/token"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/helpers"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/cli/cmd/common"
@@ -213,7 +212,7 @@ func parseIdentifier(
 		return sel, nil
 	}
 
-	addr, _, err := helpers.ResolveAddress(npa.Network, s)
+	addr, _, err := common.ResolveAddress(npa.Network, s)
 	if err == nil {
 		return addr, nil
 	}

--- a/docs/account.md
+++ b/docs/account.md
@@ -92,12 +92,16 @@ of your default account on the default network and ParaTime:
 
 ![code](../examples/account/show.out)
 
-You can also pass the name of the account in your wallet or the name stored in
-your address book:
+You can also pass the name of the account in your wallet or address book, or one
+of the [built-in named addresses](#reserved-addresses):
 
 ![code shell](../examples/account/show-named.in)
 
 ![code](../examples/account/show-named.out)
+
+![code shell](../examples/account/show-named-pool.in)
+
+![code](../examples/account/show-named-pool.out)
 
 Or, you can check the balance of an arbitrary account address by passing the
 native or Ethereum-compatible addresses.
@@ -648,3 +652,23 @@ assets anymore, but will also permanently remove the tokens from circulation.
 command.
 
 :::
+
+### Pools and Reserved Addresses {#reserved-addresses}
+
+The following literals are used in the Oasis CLI to denote special reserved
+addresses which cannot be directly used in the ledger:
+
+#### Consensus layer
+
+- `pool:consensus:burn`: The token burn address.
+- `pool:consensus:common`: The common pool address.
+- `pool:consensus:fee-accumulator`: The per-block fee accumulator address.
+- `pool:consensus:governance-deposits`: The governance deposits address.
+
+#### ParaTime layer
+
+- `pool:paratime:common`: The common pool address.
+- `pool:paratime:fee-accumulator`: The per-block fee accumulator address.
+- `pool:paratime:pending-withdrawal`: The internal pending withdrawal address.
+- `pool:paratime:pending-delegation`: The internal pending delegation address.
+- `pool:paratime:rewards`: The reward pool address.

--- a/examples/account/show-named-pool.in
+++ b/examples/account/show-named-pool.in
@@ -1,0 +1,1 @@
+oasis acc show pool:consensus:fee-accumulator

--- a/examples/account/show-named-pool.out
+++ b/examples/account/show-named-pool.out
@@ -1,0 +1,8 @@
+Address: oasis1qqnv3peudzvekhulf8v3ht29z4cthkhy7gkxmph5
+
+=== CONSENSUS LAYER (testnet) ===
+  Nonce: 0
+
+  Total: 0.0 TEST
+  Available: 0.0 TEST
+

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/oasisprotocol/deoxysii v0.0.0-20220228165953-2091330c22b7
 	github.com/oasisprotocol/metadata-registry-tools v0.0.0-20220406100644-7e9a2b991920
 	github.com/oasisprotocol/oasis-core/go v0.2300.9
-	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.7.1
+	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.7.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/oasisprotocol/metadata-registry-tools v0.0.0-20220406100644-7e9a2b991
 github.com/oasisprotocol/metadata-registry-tools v0.0.0-20220406100644-7e9a2b991920/go.mod h1:MKr/giwakLyCCjSWh0W9Pbaf7rDD1K96Wr57OhNoUK0=
 github.com/oasisprotocol/oasis-core/go v0.2300.9 h1:4Og8s40BRZzeZbyfm+GcXA2kJmLnsR1Kw9jj1JZOplk=
 github.com/oasisprotocol/oasis-core/go v0.2300.9/go.mod h1:3ub+3LT8GEjuzeAXrve9pZEDkM/goL1HKBXVp4queNM=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.7.1 h1:IAXDZDOzs44PjU9lX+MswibYI+o5ib0XmFPoDJXkdbI=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.7.1/go.mod h1:QXmki1O8UhrCWxCaByzi+UjUTb+kwNR8AYGHU348ivg=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.7.2 h1:UmKi9aaL0wFNhsxyt72EKeC8+dRX3mgAxYEMeavcXZY=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.7.2/go.mod h1:MNL4G9u8neatfQQ/AwCuGotYsUoHr6w+N7s9npMYhNQ=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=


### PR DESCRIPTION
This PR:
- Migrates ResolveAddress() from Oasis SDK to Oasis CLI
- Adds literals for the pools and other reserved addresses into address resolving code
- Documents the usage of `pool:` literal
- Bumps usage of client-sdk/go to 0.7.2

Fixes https://github.com/oasisprotocol/oasis-sdk/issues/1508