### PR TITLE
fix(cmd/paratime): Fix proposer stats

### DIFF
--- a/cmd/paratime/statistics.go
+++ b/cmd/paratime/statistics.go
@@ -379,14 +379,15 @@ var statsCmd = &cobra.Command{
 					}
 					seen[member.PublicKey] = true
 
-					if member.Role == scheduler.RoleWorker {
+					switch member.Role {
+					case scheduler.RoleWorker:
 						stats.entities[entity].roundsPrimary++
-					}
-					if member.Role == scheduler.RoleBackupWorker {
+						if member.PublicKey == currentScheduler.PublicKey {
+							stats.entities[entity].roundsProposer++
+						}
+					case scheduler.RoleBackupWorker:
 						stats.entities[entity].roundsBackup++
-					}
-					if member.PublicKey == currentScheduler.PublicKey {
-						stats.entities[entity].roundsProposer++
+					case scheduler.RoleInvalid:
 					}
 				}
 			}


### PR DESCRIPTION
Testnet:
```
./oasis paratime statistics 17993756 17993757
```

Before:

```
|                  ENTITY ADDR                   | PRIMARY | BACKUP | PROPOSER |
|------------------------------------------------|---------|--------|----------|
| oasis1qphtg2256r8q3ljs6j5yqg0em8t62ycv9q7yysls |       1 |      1 |        2 |
```

After:
```
|                  ENTITY ADDR                   | PRIMARY | BACKUP | PROPOSER |
|------------------------------------------------|---------|--------|----------|
| oasis1qphtg2256r8q3ljs6j5yqg0em8t62ycv9q7yysls |       1 |      1 |        1 |
```