### PR TITLE
docs: Make serverdir/node path consistent with other docs

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -34,6 +34,8 @@ the current Mainnet and Testnet endpoints.
 
 Invoke `network add <name> <chain-context> <rpc-endpoint>` to add a new
 endpoint with a specific chain domain separation context and a gRPC address.
+This command is useful, if you want to connect to your own instance of the Oasis
+node instead of relying on the public gRPC endpoints.
 
 For TCP/IP endpoints, run:
 
@@ -50,7 +52,7 @@ For Unix sockets, use:
 ## Add a Local Network {#add-local}
 
 `network add-local <name> <rpc-endpoint>` command can be used if you are
-running a local instance of `oasis-node`. In this case, Oasis CLI will
+running `oasis-node` on your local machine. In this case, Oasis CLI will
 autodetect the native token symbol and decimal places, the chain domain
 separation context and registered ParaTimes.
 

--- a/examples/network-set-rpc/00-list.out
+++ b/examples/network-set-rpc/00-list.out
@@ -1,5 +1,5 @@
-NAME         	CHAIN CONTEXT                                                   	RPC                                   
-mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                   	
-mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/internal.sock	
-testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443           	
-testnet_alt  	50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a	testnet2.grpc.oasis.dev:443          	
+NAME         	CHAIN CONTEXT                                                   	RPC                                        
+mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                        	
+mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/node/internal.sock	
+testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443                	
+testnet_alt  	50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a	testnet2.grpc.oasis.dev:443               	

--- a/examples/network-set-rpc/02-list.out
+++ b/examples/network-set-rpc/02-list.out
@@ -1,5 +1,5 @@
-NAME         	CHAIN CONTEXT                                                   	RPC                                   
-mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                   	
-mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/internal.sock	
-testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443           	
-testnet_alt  	50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a	testnet3.grpc.oasis.dev:443          	
+NAME         	CHAIN CONTEXT                                                   	RPC                                        
+mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                        	
+mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/node/internal.sock	
+testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443                	
+testnet_alt  	50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a	testnet3.grpc.oasis.dev:443               	

--- a/examples/network-set-rpc/config/cli.toml
+++ b/examples/network-set-rpc/config/cli.toml
@@ -94,7 +94,7 @@ default = ''
 [networks.mainnet_local]
 chain_context = 'b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535'
 description = ''
-rpc = 'unix:/serverdir_mainnet/internal.sock'
+rpc = 'unix:/serverdir_mainnet/node/internal.sock'
 
 [networks.mainnet_local.denomination]
 decimals = 9

--- a/examples/network/00-list.out
+++ b/examples/network/00-list.out
@@ -1,5 +1,5 @@
-NAME         	CHAIN CONTEXT                                                   	RPC                                   
-mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                   	
-mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/internal.sock	
-testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443           	
-testnet_alt  	50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a	testnet2.grpc.oasis.dev:443          	
+NAME         	CHAIN CONTEXT                                                   	RPC                                        
+mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                        	
+mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/node/internal.sock	
+testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443                	
+testnet_alt  	50304f98ddb656620ea817cc1446c401752a05a249b36c9b90dba4616829977a	testnet2.grpc.oasis.dev:443               	

--- a/examples/network/02-list.out
+++ b/examples/network/02-list.out
@@ -1,4 +1,4 @@
-NAME         	CHAIN CONTEXT                                                   	RPC                                   
-mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                   	
-mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/internal.sock	
-testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443           	
+NAME         	CHAIN CONTEXT                                                   	RPC                                        
+mainnet (*)  	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                        	
+mainnet_local	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/node/internal.sock	
+testnet      	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443                	

--- a/examples/network/04-list.out
+++ b/examples/network/04-list.out
@@ -1,4 +1,4 @@
-NAME             	CHAIN CONTEXT                                                   	RPC                                   
-mainnet          	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                   	
-mainnet_local (*)	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/internal.sock	
-testnet          	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443           	
+NAME             	CHAIN CONTEXT                                                   	RPC                                        
+mainnet          	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443                        	
+mainnet_local (*)	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	unix:/serverdir_mainnet/node/internal.sock	
+testnet          	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443                	

--- a/examples/network/add-unix.in.static
+++ b/examples/network/add-unix.in.static
@@ -1,1 +1,1 @@
-oasis network add testnet_local 0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76 unix:/serverdir_testnet/internal.sock
+oasis network add testnet_local 0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76 unix:/serverdir_testnet/node/internal.sock

--- a/examples/network/config/cli.toml
+++ b/examples/network/config/cli.toml
@@ -94,7 +94,7 @@ default = ''
 [networks.mainnet_local]
 chain_context = 'b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535'
 description = ''
-rpc = 'unix:/serverdir_mainnet/internal.sock'
+rpc = 'unix:/serverdir_mainnet/node/internal.sock'
 
 [networks.mainnet_local.denomination]
 decimals = 9


### PR DESCRIPTION
`internal.sock` resides in the data dir, which is `/serverdir/node` in the rest of the "Run your node" docs. In the CLI docs, we just used `/serverdir/internal.sock`. This PR adds the `node` subdirectory to make it consistent.