### PR TITLE
examples: Move wallet create commands

### DIFF
--- a/docs/addressbook.md
+++ b/docs/addressbook.md
@@ -68,6 +68,10 @@ account or simply check, if an entry exists in the address book, by running
 You can always rename the entry in your address book by using
 `addressbook rename <old_name> <new_name>`:
 
+![code shell](../examples/addressbook/03-list.in)
+
+![code](../examples/addressbook/03-list.out)
+
 ![code shell](../examples/addressbook/06-rename.in)
 
 ![code shell](../examples/addressbook/07-list.in)
@@ -78,6 +82,10 @@ You can always rename the entry in your address book by using
 
 To delete an entry from your address book invoke
 `addressbook remove <name>`.
+
+![code shell](../examples/addressbook/03-list.in)
+
+![code](../examples/addressbook/03-list.out)
 
 ![code shell](../examples/addressbook/09-remove.in)
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -86,11 +86,23 @@ To change the chain context of a network, use
 
 Chain contexts represent a root of trust in the network, so before changing them
 for production networks make sure you have verified them against a trusted
-source like the official Oasis documentation.
+source like the [Mainnet] and [Testnet] chapters in the official Oasis
+documentation.
 
 :::
 
+![code shell](../examples/network/04-list.in)
+
+![code shell](../examples/network/04-list.out)
+
 ![code shell](../examples/network/05-set-chain-context.in)
+
+![code shell](../examples/network/06-list.in)
+
+![code shell](../examples/network/06-list.out)
+
+[Mainnet]: https://github.com/oasisprotocol/docs/blob/main/docs/node/mainnet/README.md
+[Testnet]: https://github.com/oasisprotocol/docs/blob/main/docs/node/testnet/README.md
 
 ## Set Default Network {#set-default}
 

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -70,14 +70,9 @@ private key. You will have to enter the password for this account each time to
 access use it for signing the transactions (e.g. to send tokens). The account
 address is public and can be accessed without entering the passphrase.
 
-```shell
-oasis wallet create oscar
-```
+![code shell](../examples/wallet/create.in.static)
 
-```
-? Choose a new passphrase: 
-? Repeat passphrase:
-```
+![code](../examples/wallet/create.out.static)
 
 :::tip
 
@@ -91,17 +86,13 @@ flag. You can always [change the default account](#set-default) later.
 To use your hardware wallet, add `--kind ledger` parameter and Oasis CLI will
 store a reference to an account on your hardware wallet:
 
-```shell
-oasis wallet create logan --kind ledger
-```
+![code shell](../examples/wallet/create-ledger.in.static)
 
 A specific account kind (`ed25519-adr8`, `secp256k1-bip44`) and the derivation
 path number can be passed with `--file.algorithm` and `--file.number` or
 `--ledger.algorithm` and `--ledger.number` respectively. For example:
 
-```shell
-oasis wallet create lenny --kind ledger --ledger.algorithm secp256k1-bip44 --ledger.number 3
-```
+![code shell](../examples/wallet/create-ledger-secp256k1.in.static)
 
 :::tip
 
@@ -116,10 +107,9 @@ reset your Ledger with a new mnemonic, Oasis CLI will abort because the address
 of the account obtained from the new device will not match the one stored in
 your config.
 
-```
-oasis wallet show logan
-Error: address mismatch after loading account (expected: oasis1qpl4axynedmdrrgrg7dpw3yxc4a8crevr5dkuksl got: oasis1qzdyu09x7hs5nqa0sjgy5jtmz3j5f99ccq0aezjk)
-```
+![code shell](../examples/wallet/show-ledger-error.in.static)
+
+![code](../examples/wallet/show-ledger-error.out.static)
 
 :::
 
@@ -134,39 +124,15 @@ format.
 
 Importing an account with a mnemonic looks like this:
 
-```shell
-oasis wallet import eugene
-```
+![code shell](../examples/wallet/import-secp256k1-bip44.in.static)
 
-```
-? Kind: mnemonic
-? Algorithm: secp256k1-bip44
-? Key number: 0
-? Mnemonic: [Enter 2 empty lines to finish]man ankle mystery favorite tone number ice west spare marriage control lucky life together neither
-
-? Mnemonic: 
-man ankle mystery favorite tone number ice west spare marriage control lucky life together neither
-? Choose a new passphrase: 
-? Repeat passphrase:
-```
+![code](../examples/wallet/import-secp256k1-bip44.out.static)
 
 Let's make another Secp256k1 account and entering a hex-encoded raw private key:
 
-```shell
-oasis wallet import emma
-```
+![code shell](../examples/wallet/import-secp256k1-raw.in.static)
 
-```
-oasis wallet import emma
-? Kind: private key
-? Algorithm: secp256k1-raw
-? Private key (hex-encoded): [Enter 2 empty lines to finish]4811ebbe4f29f32a758f6f7bad39deb97ea67f07350637e31c75795dc679262a
-
-? Private key (hex-encoded): 
-4811ebbe4f29f32a758f6f7bad39deb97ea67f07350637e31c75795dc679262a
-? Choose a new passphrase: 
-? Repeat passphrase:
-```
+![code](../examples/wallet/import-secp256k1-raw.out.static)
 
 ## List Accounts Stored in Your Wallet {#list}
 
@@ -185,45 +151,22 @@ To verify whether an account exists in your wallet, use `wallet show <name>`.
 This will print the account's native address and the public key which requires
 entering your account's password.
 
-```shell
-oasis wallet show oscar
-```
+![code shell](../examples/wallet/show.in.static)
 
-```
-Unlock your account.
-? Passphrase:
-Name:             oscar
-Public Key:       Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8=
-Native address:   oasis1qp87hflmelnpqhzcqcw8rhzakq4elj7jzv090p3e
-```
+![code](../examples/wallet/show.out.static)
 
 For `secp256k1` accounts Ethereum's hex-encoded address will also be printed.
 
-```shell
-oasis wallet show eugene
-```
+![code shell](../examples/wallet/show-secp256k1.in.static)
 
-```
-Unlock your account.
-? Passphrase: 
-Name:             eugene
-Public Key:       ArEjDxsPfDvfeLlity4mjGzy8E/nI4umiC8vYQh+eh/c
-Ethereum address: 0xBd16C6bF701a01DF1B5C11B14860b6bDbE776669
-Native address:   oasis1qrvzxld9rz83wv92lvnkpmr30c77kj2tvg0pednz
-```
+![code](../examples/wallet/show-secp256k1.out.static)
 
 Showing an account stored on your hardware wallet will require connecting it to
 your computer:
 
-```shell
-oasis wallet show logan
-```
+![code shell](../examples/wallet/show-ledger.in.static)
 
-```
-Name:             logan
-Public Key:       l+cuboPsOeuY1+kYlROrpmKgiiELmXSw9xl0WEg8cWE=
-Native address:   oasis1qpl4axynedmdrrgrg7dpw3yxc4a8crevr5dkuksl
-```
+![code](../examples/wallet/show-ledger.out.static)
 
 ## Export the Account's Secret {#export}
 
@@ -232,70 +175,26 @@ or the private key by running `wallet export <name>`.
 
 For example:
 
-```shell
-oasis wallet export oscar
-```
+![code shell](../examples/wallet/export.in.static)
 
-```
-WARNING: Exporting the account will expose secret key material!
-Unlock your account.
-? Passphrase: 
-Name:             oscar
-Public Key:       Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8=
-Native address:   oasis1qp87hflmelnpqhzcqcw8rhzakq4elj7jzv090p3e
-Export:
-promote easily runway junior saddle gold flip believe wet example amount believe habit mixed pistol lemon increase moon rail mail fiction miss clip asset
-```
+![code](../examples/wallet/export.out.static)
 
-The same goes for Secp256k1 accounts:
+The same goes for your Secp256k1 accounts:
 
-```shell
-oasis wallet export eugene
-```
+![code shell](../examples/wallet/export-secp256k1-bip44.in.static)
 
-```
-WARNING: Exporting the account will expose secret key material!
-Unlock your account.
-? Passphrase: 
-Name:             eugene
-Public Key:       ArEjDxsPfDvfeLlity4mjGzy8E/nI4umiC8vYQh+eh/c
-Ethereum address: 0xBd16C6bF701a01DF1B5C11B14860b6bDbE776669
-Native address:   oasis1qrvzxld9rz83wv92lvnkpmr30c77kj2tvg0pednz
-Export:
-man ankle mystery favorite tone number ice west spare marriage control lucky life together neither
-```
+![code](../examples/wallet/export-secp256k1-bip44.out.static)
 
-```shell
-oasis wallet export emma
-```
+![code shell](../examples/wallet/export-secp256k1-raw.in.static)
 
-```
-WARNING: Exporting the account will expose secret key material!
-Unlock your account.
-? Passphrase: 
-Name:             emma
-Public Key:       Az8B2UpSUET0E3n9XMzr+HBvviQKcRvz6C6bJtRFWNYG
-Ethereum address: 0xeEbE22411f579682F6f9D68f4C19B3581bCb576b
-Native address:   oasis1qph93wnfw8shu04pqyarvtjy4lytz3hp0c7tqnqh
-Export:
-4811ebbe4f29f32a758f6f7bad39deb97ea67f07350637e31c75795dc679262a
-```
+![code](../examples/wallet/export-secp256k1-raw.out.static)
 
 Trying to export an account stored on your hardware wallet will only
 export its public key:
 
-```shell
-oasis wallet export lenny
-```
+![code shell](../examples/wallet/export-ledger.in.static)
 
-```
-WARNING: Exporting the account will expose secret key material!
-Name:             lenny
-Public Key:       AhhT2TUkEZ7rMasLBvHcsGj4SUO7Iw36ELEpL0evZDV1
-Ethereum address: 0x95e5e3C1BDD92cd4A0c14c62480DB5867946281D
-Native address:   oasis1qrmw4rhvp8ksj3yx6p2ftnkz864muc3re5jlgall
-Export:
-```
+![code](../examples/wallet/export-ledger.out.static)
 
 ## Renaming the Account {#rename}
 
@@ -322,22 +221,15 @@ For example, let's delete `lenny` account:
 
 ![code](../examples/wallet/00-list.out)
 
-```shell
-oasis wallet remove lenny
-```
+![code shell](../examples/wallet/remove.in.static)
 
-```
-WARNING: Removing the account will ERASE secret key material!
-WARNING: THIS ACTION IS IRREVERSIBLE!
-? Enter 'I really want to remove account lenny' (without quotes) to confirm removal: I really want to remove account lenny
-```
+![code](../examples/wallet/remove.out.static)
 
 ```shell
 oasis wallet list
 ```
 
 ```
-oasis wallet list
 ACCOUNT         KIND                            ADDRESS                                        
 emma            file (secp256k1-raw)            oasis1qph93wnfw8shu04pqyarvtjy4lytz3hp0c7tqnqh
 eugene          file (secp256k1-bip44:0)        oasis1qrvzxld9rz83wv92lvnkpmr30c77kj2tvg0pednz
@@ -370,14 +262,9 @@ to submit their governance transaction, for example to vote on the network
 upgrade using the Oasis CLI, they need to import the key into the Oasis CLI
 wallet:
 
-```shell
-oasis wallet import-file my_entity entity.pem
-```
+![code shell](../examples/wallet/import-file.in.static)
 
-```
-? Choose a new passphrase: 
-? Repeat passphrase:
-```
+![code](../examples/wallet/import-file.out.static)
 
 The key is now safely stored and encrypted inside the Oasis CLI.
 
@@ -397,27 +284,16 @@ You can bind the account in your Oasis CLI wallet with a local instance of
 `wallet remote-signer <account_name> <socket_path>`, pick the account you wish
 to expose and provide a path to the new unix socket:
 
-```shell
-oasis wallet remote-signer oscar /datadir/oasis-oscar.socket
-```
+![code shell](../examples/wallet/remote-signer.in.static)
 
-```
-Unlock your account.
-? Passphrase: 
-Address: oasis1qp87hflmelnpqhzcqcw8rhzakq4elj7jzv090p3e
-Node Args:
-  --signer.backend=remote \
-  --signer.remote.address=unix:/datadir/oasis-oscar.socket
-
-*** REMOTE SIGNER READY ***
-```
+![code](../examples/wallet/remote-signer.out.static)
 
 ### Test Accounts {#test-accounts}
 
 Oasis CLI comes with the following hardcoded test accounts:
 
-- `test:alice`: Ed25519 test account by Oasis core tests
-- `test:bob`: Ed25519 test account by Oasis core tests
+- `test:alice`: Ed25519 test account used by Oasis core tests
+- `test:bob`: Ed25519 test account used by Oasis core tests
 - `test:charlie`: Secp256k1 test account
 - `test:cory`: Ed25519 account used by `oasis-net-runner`
 - `test:dave`: Secp256k1 test account

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -202,6 +202,10 @@ To rename an account, run `wallet rename <old_name> <new_name>`.
 
 For example:
 
+![code shell](../examples/wallet/00-list.in)
+
+![code](../examples/wallet/00-list.out)
+
 ![code shell](../examples/wallet/01-rename.in)
 
 ![code shell](../examples/wallet/02-list.in)
@@ -310,4 +314,4 @@ networks, because anyone can drain them!
 We suggest that you use these accounts for Localnet development or for
 reproducibility when you report bugs to the Oasis core team. You can access the
 private key of a test account the same way as you would for ordinary accounts
-by running `wallet export`.
+by invoking the [`oasis wallet export`](#export) command.

--- a/examples/network/05-set-chain-context.in
+++ b/examples/network/05-set-chain-context.in
@@ -1,1 +1,1 @@
-oasis network set-chain-context mainnet_local b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+oasis network set-chain-context mainnet_local 01234513331133a715c7a150313877dF1d33e77a715c7a150313877dF1d33e77

--- a/examples/network/06-list.in
+++ b/examples/network/06-list.in
@@ -1,0 +1,1 @@
+oasis network list

--- a/examples/network/06-list.out
+++ b/examples/network/06-list.out
@@ -1,0 +1,4 @@
+NAME             	CHAIN CONTEXT                                                   	RPC                           
+mainnet          	b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535	grpc.oasis.dev:443           	
+mainnet_local (*)	01234513331133a715c7a150313877dF1d33e77a715c7a150313877dF1d33e77	unix:/node/data/internal.sock	
+testnet          	0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76	testnet.grpc.oasis.dev:443   	

--- a/examples/wallet/create-ledger-secp256k1.in.static
+++ b/examples/wallet/create-ledger-secp256k1.in.static
@@ -1,0 +1,1 @@
+oasis wallet create logan --kind ledger

--- a/examples/wallet/create-ledger.in.static
+++ b/examples/wallet/create-ledger.in.static
@@ -1,0 +1,1 @@
+oasis wallet create logan --kind ledger

--- a/examples/wallet/create.in.static
+++ b/examples/wallet/create.in.static
@@ -1,0 +1,1 @@
+oasis wallet create oscar

--- a/examples/wallet/create.out.static
+++ b/examples/wallet/create.out.static
@@ -1,0 +1,2 @@
+? Choose a new passphrase:
+? Repeat passphrase:

--- a/examples/wallet/export-ledger.in.static
+++ b/examples/wallet/export-ledger.in.static
@@ -1,0 +1,1 @@
+oasis wallet export lenny

--- a/examples/wallet/export-ledger.out.static
+++ b/examples/wallet/export-ledger.out.static
@@ -1,0 +1,6 @@
+WARNING: Exporting the account will expose secret key material!
+Name:             lenny
+Public Key:       AhhT2TUkEZ7rMasLBvHcsGj4SUO7Iw36ELEpL0evZDV1
+Ethereum address: 0x95e5e3C1BDD92cd4A0c14c62480DB5867946281D
+Native address:   oasis1qrmw4rhvp8ksj3yx6p2ftnkz864muc3re5jlgall
+Export:

--- a/examples/wallet/export-secp256k1-bip44.in.static
+++ b/examples/wallet/export-secp256k1-bip44.in.static
@@ -1,0 +1,1 @@
+oasis wallet export eugene

--- a/examples/wallet/export-secp256k1-bip44.out.static
+++ b/examples/wallet/export-secp256k1-bip44.out.static
@@ -1,0 +1,9 @@
+WARNING: Exporting the account will expose secret key material!
+Unlock your account.
+? Passphrase:
+Name:             eugene
+Public Key:       ArEjDxsPfDvfeLlity4mjGzy8E/nI4umiC8vYQh+eh/c
+Ethereum address: 0xBd16C6bF701a01DF1B5C11B14860b6bDbE776669
+Native address:   oasis1qrvzxld9rz83wv92lvnkpmr30c77kj2tvg0pednz
+Export:
+man ankle mystery favorite tone number ice west spare marriage control lucky life together neither

--- a/examples/wallet/export-secp256k1-raw.in.static
+++ b/examples/wallet/export-secp256k1-raw.in.static
@@ -1,0 +1,1 @@
+oasis wallet export emma

--- a/examples/wallet/export-secp256k1-raw.out.static
+++ b/examples/wallet/export-secp256k1-raw.out.static
@@ -1,0 +1,9 @@
+WARNING: Exporting the account will expose secret key material!
+Unlock your account.
+? Passphrase:
+Name:             emma
+Public Key:       Az8B2UpSUET0E3n9XMzr+HBvviQKcRvz6C6bJtRFWNYG
+Ethereum address: 0xeEbE22411f579682F6f9D68f4C19B3581bCb576b
+Native address:   oasis1qph93wnfw8shu04pqyarvtjy4lytz3hp0c7tqnqh
+Export:
+4811ebbe4f29f32a758f6f7bad39deb97ea67f07350637e31c75795dc679262a

--- a/examples/wallet/export.in.static
+++ b/examples/wallet/export.in.static
@@ -1,0 +1,1 @@
+oasis wallet export oscar

--- a/examples/wallet/export.out.static
+++ b/examples/wallet/export.out.static
@@ -1,0 +1,8 @@
+WARNING: Exporting the account will expose secret key material!
+Unlock your account.
+? Passphrase:
+Name:             oscar
+Public Key:       Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8=
+Native address:   oasis1qp87hflmelnpqhzcqcw8rhzakq4elj7jzv090p3e
+Export:
+promote easily runway junior saddle gold flip believe wet example amount believe habit mixed pistol lemon increase moon rail mail fiction miss clip asset

--- a/examples/wallet/import-file.in.static
+++ b/examples/wallet/import-file.in.static
@@ -1,0 +1,1 @@
+oasis wallet import-file my_entity entity.pem

--- a/examples/wallet/import-file.out.static
+++ b/examples/wallet/import-file.out.static
@@ -1,0 +1,2 @@
+? Choose a new passphrase:
+? Repeat passphrase:

--- a/examples/wallet/import-secp256k1-bip44.in.static
+++ b/examples/wallet/import-secp256k1-bip44.in.static
@@ -1,0 +1,1 @@
+oasis wallet import eugene

--- a/examples/wallet/import-secp256k1-bip44.out.static
+++ b/examples/wallet/import-secp256k1-bip44.out.static
@@ -1,0 +1,9 @@
+? Kind: mnemonic
+? Algorithm: secp256k1-bip44
+? Key number: 0
+? Mnemonic: [Enter 2 empty lines to finish]man ankle mystery favorite tone number ice west spare marriage control lucky life together neither
+
+? Mnemonic:
+man ankle mystery favorite tone number ice west spare marriage control lucky life together neither
+? Choose a new passphrase:
+? Repeat passphrase:

--- a/examples/wallet/import-secp256k1-raw.in.static
+++ b/examples/wallet/import-secp256k1-raw.in.static
@@ -1,0 +1,1 @@
+oasis wallet import emma

--- a/examples/wallet/import-secp256k1-raw.out.static
+++ b/examples/wallet/import-secp256k1-raw.out.static
@@ -1,0 +1,9 @@
+oasis wallet import emma
+? Kind: private key
+? Algorithm: secp256k1-raw
+? Private key (hex-encoded): [Enter 2 empty lines to finish]4811ebbe4f29f32a758f6f7bad39deb97ea67f07350637e31c75795dc679262a
+
+? Private key (hex-encoded):
+4811ebbe4f29f32a758f6f7bad39deb97ea67f07350637e31c75795dc679262a
+? Choose a new passphrase:
+? Repeat passphrase:

--- a/examples/wallet/remote-signer.in.static
+++ b/examples/wallet/remote-signer.in.static
@@ -1,0 +1,1 @@
+oasis wallet remote-signer oscar /datadir/oasis-oscar.socket

--- a/examples/wallet/remote-signer.out.static
+++ b/examples/wallet/remote-signer.out.static
@@ -1,0 +1,8 @@
+Unlock your account.
+? Passphrase:
+Address: oasis1qp87hflmelnpqhzcqcw8rhzakq4elj7jzv090p3e
+Node Args:
+  --signer.backend=remote \
+  --signer.remote.address=unix:/datadir/oasis-oscar.socket
+
+*** REMOTE SIGNER READY ***

--- a/examples/wallet/remove.in.static
+++ b/examples/wallet/remove.in.static
@@ -1,0 +1,1 @@
+oasis wallet remove lenny

--- a/examples/wallet/remove.out.static
+++ b/examples/wallet/remove.out.static
@@ -1,0 +1,3 @@
+WARNING: Removing the account will ERASE secret key material!
+WARNING: THIS ACTION IS IRREVERSIBLE!
+? Enter 'I really want to remove account lenny' (without quotes) to confirm removal: I really want to remove account lenny

--- a/examples/wallet/show-ledger-error.in.static
+++ b/examples/wallet/show-ledger-error.in.static
@@ -1,0 +1,1 @@
+oasis wallet show logan

--- a/examples/wallet/show-ledger-error.out.static
+++ b/examples/wallet/show-ledger-error.out.static
@@ -1,0 +1,1 @@
+Error: address mismatch after loading account (expected: oasis1qpl4axynedmdrrgrg7dpw3yxc4a8crevr5dkuksl got: oasis1qzdyu09x7hs5nqa0sjgy5jtmz3j5f99ccq0aezjk)

--- a/examples/wallet/show-ledger.in.static
+++ b/examples/wallet/show-ledger.in.static
@@ -1,0 +1,1 @@
+oasis wallet show logan

--- a/examples/wallet/show-ledger.out.static
+++ b/examples/wallet/show-ledger.out.static
@@ -1,0 +1,3 @@
+Name:             logan
+Public Key:       l+cuboPsOeuY1+kYlROrpmKgiiELmXSw9xl0WEg8cWE=
+Native address:   oasis1qpl4axynedmdrrgrg7dpw3yxc4a8crevr5dkuksl

--- a/examples/wallet/show-secp256k1.in.static
+++ b/examples/wallet/show-secp256k1.in.static
@@ -1,0 +1,1 @@
+oasis wallet show eugene

--- a/examples/wallet/show-secp256k1.out.static
+++ b/examples/wallet/show-secp256k1.out.static
@@ -1,0 +1,6 @@
+Unlock your account.
+? Passphrase:
+Name:             eugene
+Public Key:       ArEjDxsPfDvfeLlity4mjGzy8E/nI4umiC8vYQh+eh/c
+Ethereum address: 0xBd16C6bF701a01DF1B5C11B14860b6bDbE776669
+Native address:   oasis1qrvzxld9rz83wv92lvnkpmr30c77kj2tvg0pednz

--- a/examples/wallet/show.in.static
+++ b/examples/wallet/show.in.static
@@ -1,0 +1,1 @@
+oasis wallet show oscar

--- a/examples/wallet/show.out.static
+++ b/examples/wallet/show.out.static
@@ -1,0 +1,5 @@
+Unlock your account.
+? Passphrase:
+Name:             oscar
+Public Key:       Bx6gOixnxy15tCs09ua5DcKyX9uo2Forb32O6Hyjoc8=
+Native address:   oasis1qp87hflmelnpqhzcqcw8rhzakq4elj7jzv090p3e


### PR DESCRIPTION
This PR:
- Moves `oasis wallet` snippets from `wallet.md` to separate examples snippet files so they can be included also in other parts of the docs (e.g. quick cheat commands).
- Extends a few `oasis wallet`, `oasis network` and `oasis addressbook` commands a bit for clarity.