### PR TITLE
deps: Bump golangci-lint

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -63,7 +63,7 @@ jobs:
         # 'make lint-go'.
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.52.0
+          version: v1.55
         # Always run this step so that all linting errors can be seen at once.
         if: always()
       - name: Ensure a clean code checkout

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,6 +49,27 @@ linters:
     - whitespace
 
 linters-settings:
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+        allow:
+          - $gostd
+          - github.com/oasisprotocol
+          - github.com/btcsuite/btcd
+          - github.com/adrg/xdg
+          - github.com/AlecAivazis/survey/v2
+          - github.com/ethereum/go-ethereum
+          - github.com/miguelmota/go-ethereum-hdwallet
+          - github.com/mitchellh/mapstructure
+          - github.com/olekukonko/tablewriter
+          - github.com/spf13/cobra
+          - github.com/spf13/pflag
+          - github.com/spf13/viper
+          - github.com/stretchr/testify
+          - github.com/tyler-smith/go-bip39
+          - github.com/zondax/ledger-go
   exhaustive:
     # Switch statements are to be considered exhaustive if a 'default' case is
     # present, even if all enum members aren't listed in the switch.

--- a/wallet/file/sr25519.go
+++ b/wallet/file/sr25519.go
@@ -71,7 +71,7 @@ func newMasterKey(seed []byte) (sdkSignature.Signer, slip10.ChainCode, []byte, e
 	return splitDigest(I)
 }
 
-func newChildKey(kPar []byte, cPar slip10.ChainCode, index uint32) (sdkSignature.Signer, slip10.ChainCode, []byte, error) { //nolint: revive
+func newChildKey(kPar []byte, cPar slip10.ChainCode, index uint32) (sdkSignature.Signer, slip10.ChainCode, []byte, error) {
 	if len(kPar) < memory.SeedSize {
 		return nil, slip10.ChainCode{}, nil, fmt.Errorf("slip10: invalid parent key")
 	}


### PR DESCRIPTION
This PR:
- bumps golangci-lint in CI to v1.55.x
- fixes one linting error
- adds allowlist of packages for `depguard`

Unblocks https://github.com/oasisprotocol/cli/pull/182