### PR TITLE
docs: Line number requires specified language

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -40,7 +40,7 @@ signature:
 
 ![code shell](../examples/transaction/show-invalid.in)
 
-![code {4}](../examples/transaction/show-invalid.out)
+![code text {4}](../examples/transaction/show-invalid.out)
 
 The `show` command is also compatible with ParaTime transactions. Take the
 following transaction which transfers `1.0 TEST` from `test:alice` to `test:bob`


### PR DESCRIPTION
This is the behavior introduced by https://github.com/oasisprotocol/docs/pull/820. This is also the same as in the official markdown code block.

e.g. This doesn't work

````
```{2-3}
a
b
c
d
```
````

but this does:
````
```text {2-3}
a
b
c
d
```
````
