### PR TITLE
cmd: Add subtract-fee flag

### DIFF
--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -2,17 +2,27 @@ package account
 
 import (
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 
 	"github.com/oasisprotocol/cli/cmd/account/show"
 )
 
-var Cmd = &cobra.Command{
-	Use:     "account",
-	Short:   "Account operations",
-	Aliases: []string{"a", "acc", "accounts"},
-}
+var (
+	subtractFee bool
+	// SubtractFeeFlags enables makes the provided amount also contain any transaction fees.
+	SubtractFeeFlags *flag.FlagSet
+
+	Cmd = &cobra.Command{
+		Use:     "account",
+		Short:   "Account operations",
+		Aliases: []string{"a", "acc", "accounts"},
+	}
+)
 
 func init() {
+	SubtractFeeFlags = flag.NewFlagSet("", flag.ContinueOnError)
+	SubtractFeeFlags.BoolVar(&subtractFee, "subtract-fee", false, "subtract fee from the amount")
+
 	Cmd.AddCommand(allowCmd)
 	Cmd.AddCommand(amendCommissionScheduleCmd)
 	Cmd.AddCommand(burnCmd)

--- a/cmd/common/selector.go
+++ b/cmd/common/selector.go
@@ -25,7 +25,7 @@ var (
 var (
 	// AccountFlag corresponds to the --account selector flag.
 	AccountFlag *flag.FlagSet
-	// SelectorFlags contains the common selector flags for network/ParaTime/wallet.
+	// SelectorFlags contains the common selector flags for network/ParaTime/account.
 	SelectorFlags *flag.FlagSet
 	// SelectorNPFlags contains the common selector flags for network/ParaTime.
 	SelectorNPFlags *flag.FlagSet

--- a/docs/account.md
+++ b/docs/account.md
@@ -231,6 +231,13 @@ Consensus layer token transfers:
 
 :::
 
+:::info
+
+The [`--subtract-fee`](#subtract-fee) flag is available both for consensus
+and ParaTime transfers.
+
+:::
+
 ## Allowance {#allow}
 
 `account allow <beneficiary> <amount>` command makes your funds withdrawable by
@@ -361,6 +368,13 @@ not supported on the consensus layer!
 
 [Network, ParaTime and account](#npa) selectors are available for the
 `account withdraw` command.
+
+:::
+
+:::info
+
+The [`--subtract-fee`](#subtract-fee) flag is available for withdrawal
+transactions.
 
 :::
 
@@ -527,6 +541,16 @@ automatically obtained from the network. Oasis CLI will print the transaction to
 the standard output for you to examine. Use [`--output-file`](#output-file), if
 you wish to save the transaction to the file and submit it to the network
 afterwards by using the [`transaction submit`][transaction-submit] command.
+
+### Subtract fee {#subtract-fee}
+
+To include the transaction fee inside the given amount, pass the
+`--subtract-fee` flag. This comes handy, if you want to drain the account or
+keep it rounded to some specific number.
+
+![code shell](../examples/account/transfer-subtract-fee.y.in)
+
+![code shell](../examples/account/transfer-subtract-fee.y.out)
 
 ### Account's Nonce {#nonce}
 

--- a/examples/account/allow-paratime.y.out
+++ b/examples/account/allow-paratime.y.out
@@ -6,7 +6,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1278
+  Gas limit: 1286
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/allow.y.out
+++ b/examples/account/allow.y.out
@@ -6,7 +6,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1278
+  Gas limit: 1286
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/amend-commission-schedule.y.out
+++ b/examples/account/amend-commission-schedule.y.out
@@ -15,7 +15,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1361
+  Gas limit: 1369
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/burn.y.out
+++ b/examples/account/burn.y.out
@@ -5,7 +5,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1235
+  Gas limit: 1243
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/delegate.y.out
+++ b/examples/account/delegate.y.out
@@ -6,7 +6,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1271
+  Gas limit: 1279
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/entity-deregister.y.out
+++ b/examples/account/entity-deregister.y.out
@@ -5,7 +5,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1231
+  Gas limit: 1239
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/entity-register.y.out
+++ b/examples/account/entity-register.y.out
@@ -19,7 +19,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 2471
+  Gas limit: 2479
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/node-unfreeze.y.out
+++ b/examples/account/node-unfreeze.y.out
@@ -7,7 +7,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1274
+  Gas limit: 1282
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/transfer-named-no-paratime.y.out
+++ b/examples/account/transfer-named-no-paratime.y.out
@@ -6,7 +6,7 @@ Body:
 Nonce:  0
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1264
+  Gas limit: 1272
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/account/transfer-subtract-fee.y.in
+++ b/examples/account/transfer-subtract-fee.y.in
@@ -1,0 +1,1 @@
+oasis account transfer 1.0 0xDce075E1C39b1ae0b75D554558b6451A226ffe00 --account orlando --subtract-fee

--- a/examples/account/transfer-subtract-fee.y.out
+++ b/examples/account/transfer-subtract-fee.y.out
@@ -1,0 +1,17 @@
+You are about to sign the following transaction:
+Format: plain
+Method: accounts.Transfer
+Body:
+  To: test:dave (oasis1qrk58a6j2qn065m6p06jgjyt032f7qucy5wqeqpt)
+  Amount: 0.999769 TEST
+Authorized signer(s):
+  1. cb+NHKt7JT4fumy0wQdkiBwO3P+DUh8ylozMpsu1xH4= (ed25519)
+     Nonce: 0
+Fee:
+  Amount: 0.000231 TEST
+  Gas limit: 2310
+  (gas price: 0.0000001 TEST per gas unit)
+
+Network:  testnet
+ParaTime: sapphire
+Account:  orlando

--- a/examples/account/undelegate.y.out
+++ b/examples/account/undelegate.y.out
@@ -6,7 +6,7 @@ Body:
 Nonce:  2
 Fee:
   Amount: 0.0 TEST
-  Gas limit: 1275
+  Gas limit: 1283
   (gas price: 0.0 TEST per gas unit)
 
 Network:  testnet

--- a/examples/transaction/sign.y.out
+++ b/examples/transaction/sign.y.out
@@ -3,7 +3,7 @@ Method: staking.Transfer
 Body:
   To:     oasis1qrydpazemvuwtnp3efm7vmfvg3tde044qg6cxwzx
   Amount: 1.0 TEST
-Nonce:  50
+Nonce:  32
 Fee:
   Amount: 0.0 TEST
   Gas limit: 1265


### PR DESCRIPTION
This PR decouples gas fee computation and signing the transactions. If `--subtract-fee` is provided, then the fee is subtracted from the transaction before signing it.

**Note**: Gas estimation for consensus transactions is higher for 8, because the nonce and the fee objects are now populated in the tx before estimating the gas.

Implements #247 