### PR TITLE
feat(cmd/wallet): Add -y flag to export and show

### DIFF
--- a/cmd/wallet/export.go
+++ b/cmd/wallet/export.go
@@ -37,3 +37,7 @@ var exportCmd = &cobra.Command{
 		}
 	},
 }
+
+func init() {
+	exportCmd.Flags().AddFlagSet(common.AnswerYesFlag)
+}

--- a/cmd/wallet/import.go
+++ b/cmd/wallet/import.go
@@ -24,7 +24,7 @@ var (
 	kind       wallet.ImportKind
 
 	importCmd = &cobra.Command{
-		Use:   "import <name> [flags]",
+		Use:   "import <name>",
 		Short: "Import an existing account",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/wallet/show.go
+++ b/cmd/wallet/show.go
@@ -40,3 +40,7 @@ func showPublicWalletInfo(name string, wallet wallet.Account, accCfg *config.Acc
 	}
 	fmt.Printf("Native address:   %s\n", wallet.Address())
 }
+
+func init() {
+	showCmd.Flags().AddFlagSet(common.AnswerYesFlag)
+}


### PR DESCRIPTION
Add support for the `-y` flag to `oasis wallet export` and `oasis wallet show`.
This functionality is required for https://github.com/oasisprotocol/oasis-web3-gateway/pull/633.