### PR TITLE
docs: reference Sapphire localnet consolidated page under tools

### DIFF
--- a/docs/rofl.md
+++ b/docs/rofl.md
@@ -64,7 +64,7 @@ The following SGX-specific flags are supported:
   Core runtime], otherwise the app may crash during the execution under actual
   SGX. It can be greater, if the app needs to spawn more threads.
 
-[Sapphire Localnet]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/docs/guide.mdx#running-a-private-oasis-network-locally
+[Sapphire Localnet]: https://github.com/oasisprotocol/docs/blob/main/docs/dapp/tools/localnet.mdx
 [Oasis Core runtime]: https://github.com/oasisprotocol/oasis-core/blob/master/runtime/THREADS.md
 
 <!-- TODO


### PR DESCRIPTION
## Description

Necessary for https://github.com/oasisprotocol/docs/issues/959. Blocked by https://github.com/oasisprotocol/docs/pull/977