### PR TITLE
Add `oasis paratime show parameters` to show ROFL staking thresholds

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -34,10 +34,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Set up Node.js 18
+      - name: Set up Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/cmd/common/transaction.go
+++ b/cmd/common/transaction.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 
-	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	coreSignature "github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	consensusPretty "github.com/oasisprotocol/oasis-core/go/common/prettyprint"
@@ -352,31 +351,9 @@ func SignParaTimeTransaction(
 
 // PrintTransactionRaw prints the transaction which can be either signed or unsigned.
 func PrintTransactionRaw(npa *NPASelection, tx interface{}) {
-	switch rtx := tx.(type) {
+	switch tx.(type) {
 	case consensusPretty.PrettyPrinter:
-		// Signed or unsigned consensus or runtime transaction.
-		var ns common.Namespace
-		if npa.ParaTime != nil {
-			ns = npa.ParaTime.Namespace()
-		}
-		sigCtx := signature.RichContext{
-			RuntimeID:    ns,
-			ChainContext: npa.Network.ChainContext,
-			Base:         types.SignatureContextBase,
-		}
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, consensusPretty.ContextKeyTokenSymbol, npa.Network.Denomination.Symbol)
-		ctx = context.WithValue(ctx, consensusPretty.ContextKeyTokenValueExponent, npa.Network.Denomination.Decimals)
-		if npa.ParaTime != nil {
-			ctx = context.WithValue(ctx, config.ContextKeyParaTimeCfg, npa.ParaTime)
-		}
-		ctx = context.WithValue(ctx, signature.ContextKeySigContext, &sigCtx)
-		ctx = context.WithValue(ctx, types.ContextKeyAccountNames, GenAccountNames())
-
-		// Set up chain context for signature verification during pretty-printing.
-		coreSignature.UnsafeResetChainContext()
-		coreSignature.SetChainContext(npa.Network.ChainContext)
-		rtx.PrettyPrint(ctx, "", os.Stdout)
+		fmt.Print(PrettyPrint(npa, "", tx))
 	default:
 		fmt.Printf("[unsupported transaction type: %T]\n", tx)
 	}

--- a/cmd/network/show.go
+++ b/cmd/network/show.go
@@ -253,7 +253,7 @@ var showCmd = &cobra.Command{
 				}
 				return
 			case selParameters:
-				showParameters(ctx, height, consensusConn)
+				showParameters(ctx, npa, height, consensusConn)
 				return
 
 			default:
@@ -390,31 +390,7 @@ func showNativeToken(ctx context.Context, height int64, npa *common.NPASelection
 	}
 }
 
-func PrettifyFromJSON(blob interface{}) string {
-	pp, err := json.MarshalIndent(blob, "", "  ")
-	cobra.CheckErr(err)
-
-	out := string(pp)
-	out = strings.ReplaceAll(out, "{", "")
-	out = strings.ReplaceAll(out, "}", "")
-	out = strings.ReplaceAll(out, "[", "")
-	out = strings.ReplaceAll(out, "]", "")
-	out = strings.ReplaceAll(out, ",", "")
-	out = strings.ReplaceAll(out, "\"", "")
-
-	ret := ""
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimRight(line, " \n")
-		if len(line) == 0 {
-			continue
-		}
-		ret += line + "\n"
-	}
-
-	return ret
-}
-
-func showParameters(ctx context.Context, height int64, cons consensus.ClientBackend) {
+func showParameters(ctx context.Context, npa *common.NPASelection, height int64, cons consensus.ClientBackend) {
 	checkErr := func(what string, err error) {
 		if err != nil {
 			cobra.CheckErr(fmt.Errorf("%s: %w", what, err))
@@ -456,7 +432,7 @@ func showParameters(ctx context.Context, height int64, cons consensus.ClientBack
 			doc[name] = params
 		} else {
 			fmt.Printf("=== %s PARAMETERS ===\n", strings.ToUpper(name))
-			out := PrettifyFromJSON(params)
+			out := common.PrettyPrint(npa, "  ", params)
 			fmt.Printf("%s\n", out)
 		}
 	}

--- a/docs/network.md
+++ b/docs/network.md
@@ -332,24 +332,28 @@ We can see that the token's name is ROSE and that 1 token corresponds to 10^9
 Next, we can observe that the **total supply** is 10 billion tokens and that
 about 1.3 billion tokens are in the **common pool**.
 
-**Staking thresholds** are important for the network validators. They show
-the minimum staked amount required to become an active validator for the entity
-and all node kinds (validator, compute, key manager nodes). At time of writing,
-this was 100 tokens. For example, if you wanted to register an entity running a
-validator and a compute node, you would need to stake (i.e. *escrow*) at least
-300 tokens.
+The **staking thresholds** fields are the following:
+
+- `entity`: The amount needed to be staked when registering an entity.
+- `node-validator`, `node-compute`, `node-keymanager`: The amount needed to be
+  staked to the corresponding entity for a node to run as a validator, a compute
+  node or a key manager. This is the amount that will be slashed in case of
+  inappropriate node behavior.
+- `runtime-compute`, `runtime-keymanager`: The amount needed to be staked to an
+  entity for [registering a new ParaTime or a key manager](./paratime.md#register).
+  Keep in mind that a ParaTime cannot be unregistered and there is no way of
+  getting the staked assets back.
+
+For example, if you wanted to register an entity running a validator and a
+compute node, you would need to stake (i.e. *escrow*) at least 300 tokens.
 
 :::info
 
-Each runtime may also require a **minimum ParaTime-specific escrow** for
-running a compute node. Use the [`network show id`](#show-id)
-command and pass a corresponding Paratime ID to see it.
+Apart from the `node-compute` threshold above, a ParaTime may require additional
+**ParaTime-specific escrow** for running a compute node. Use the
+[`network show id`](#show-id) command to see it.
 
 :::
-
-The `runtime-` fields show you the required staked amount for
-[**registering a new ParaTime**](./paratime.md#register) of any kind (compute,
-key manager) was 50,000 tokens at time of writing.
 
 #### `gas-costs` {#show-gas-costs}
 
@@ -386,10 +390,20 @@ The provided ID can be one of the following:
   ![code json](../examples/network-show/id-paratime.out.static)
 
   Network validators may be interested in the **ParaTime staking threshold**
-  stored inside the `thresholds` field. In the example above, the amount to run
-  a Sapphire compute node on the Mainnet is 5,000,000 tokens and should be
-  considered on top of the consensus-layer validator staking thresholds
-  obtained by the [`network show native-token`](#show-native-token) command.
+  stored inside the `thresholds` field:
+
+  ```shell
+  oasis network show 000000000000000000000000000000000000000000000000f80306c9858e7279 | jq '.staking.thresholds."node-compute"'
+  ```
+  
+  ```
+  "5000000000000000"
+  ```
+
+  In the example above, the amount to run a Sapphire compute node on the Mainnet
+  is 5,000,000 tokens and should be considered on top of the consensus-layer
+  validator staking thresholds obtained by the
+  [`network show native-token`](#show-native-token) command.
 
 - If the entity ID is provided, Oasis CLI shows information on the entity and
   its corresponding nodes in the network registry. For example:

--- a/docs/network.md
+++ b/docs/network.md
@@ -340,7 +340,7 @@ The **staking thresholds** fields are the following:
   node or a key manager. This is the amount that will be slashed in case of
   inappropriate node behavior.
 - `runtime-compute`, `runtime-keymanager`: The amount needed to be staked to an
-  entity for [registering a new ParaTime or a key manager](./paratime.md#register).
+  entity for [registering a new ParaTime or a key manager].
   Keep in mind that a ParaTime cannot be unregistered and there is no way of
   getting the staked assets back.
 
@@ -354,6 +354,8 @@ Apart from the `node-compute` threshold above, a ParaTime may require additional
 [`network show id`](#show-id) command to see it.
 
 :::
+
+[registering a new ParaTime or a key manager]: ./paratime.md#register
 
 #### `gas-costs` {#show-gas-costs}
 

--- a/docs/paratime.md
+++ b/docs/paratime.md
@@ -125,8 +125,13 @@ For example, to set the Cipher ParaTime default on the Testnet, run:
 
 ## Show {#show}
 
-Use `paratime show <block>` providing the block round to print its header and
-other information.
+Use `paratime show` to investigate a specific ParaTime block or other
+parameters.
+
+### `<round>` {#show-round}
+
+Providing the block round or `latest` literal will print its header and other
+information.
 
 ![code shell](../examples/paratime-show/show.in.static)
 
@@ -146,6 +151,17 @@ encrypted:
 ![code shell](../examples/paratime-show/show-tx-encrypted.in.static)
 
 ![code](../examples/paratime-show/show-tx-encrypted.out.static)
+
+### `parameters` {#show-parameters}
+
+This will print various ParaTime-specific parameters such as the ROFL stake
+thresholds.
+
+![code shell](../examples/paratime-show/show-parameters.in)
+
+![code](../examples/paratime-show/show-parameters.out)
+
+By passing `--format json`, the output is formatted as JSON.
 
 ## Set information about a denomination {#denom-set}
 

--- a/examples/paratime-show/config/cli.toml
+++ b/examples/paratime-show/config/cli.toml
@@ -1,0 +1,119 @@
+last_migration = 1
+
+[networks]
+default = 'testnet'
+
+[networks.mainnet]
+chain_context = 'bb3d748def55bdfb797a2ac53ee6ee141e54cd2ab2dc2375f4a0703a178e6e55'
+description = ''
+rpc = 'grpc.oasis.io:443'
+
+[networks.mainnet.denomination]
+decimals = 9
+symbol = 'ROSE'
+
+[networks.mainnet.paratimes]
+default = 'sapphire'
+
+[networks.mainnet.paratimes.cipher]
+consensus_denomination = '_'
+description = ''
+id = '000000000000000000000000000000000000000000000000e199119c992377cb'
+
+[networks.mainnet.paratimes.cipher.denominations]
+[networks.mainnet.paratimes.cipher.denominations._]
+decimals = 9
+symbol = 'ROSE'
+
+[networks.mainnet.paratimes.emerald]
+consensus_denomination = '_'
+description = ''
+id = '000000000000000000000000000000000000000000000000e2eaa99fc008f87f'
+
+[networks.mainnet.paratimes.emerald.denominations]
+[networks.mainnet.paratimes.emerald.denominations._]
+decimals = 18
+symbol = 'ROSE'
+
+[networks.mainnet.paratimes.sapphire]
+consensus_denomination = '_'
+description = ''
+id = '000000000000000000000000000000000000000000000000f80306c9858e7279'
+
+[networks.mainnet.paratimes.sapphire.denominations]
+[networks.mainnet.paratimes.sapphire.denominations._]
+decimals = 18
+symbol = 'ROSE'
+
+[networks.testnet]
+chain_context = '0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76'
+description = ''
+rpc = 'testnet.grpc.oasis.io:443'
+
+[networks.testnet.denomination]
+decimals = 9
+symbol = 'TEST'
+
+[networks.testnet.paratimes]
+default = 'sapphire'
+
+[networks.testnet.paratimes.cipher]
+consensus_denomination = '_'
+description = ''
+id = '0000000000000000000000000000000000000000000000000000000000000000'
+
+[networks.testnet.paratimes.cipher.denominations]
+[networks.testnet.paratimes.cipher.denominations._]
+decimals = 9
+symbol = 'TEST'
+
+[networks.testnet.paratimes.emerald]
+consensus_denomination = '_'
+description = ''
+id = '00000000000000000000000000000000000000000000000072c8215e60d5bca7'
+
+[networks.testnet.paratimes.emerald.denominations]
+[networks.testnet.paratimes.emerald.denominations._]
+decimals = 18
+symbol = 'TEST'
+
+[networks.testnet.paratimes.pontusx_dev]
+consensus_denomination = 'TEST'
+description = 'Pontus-X Devnet'
+id = '0000000000000000000000000000000000000000000000004febe52eb412b421'
+
+[networks.testnet.paratimes.pontusx_dev.denominations]
+[networks.testnet.paratimes.pontusx_dev.denominations._]
+decimals = 18
+symbol = 'EUROe'
+
+[networks.testnet.paratimes.pontusx_dev.denominations.test]
+decimals = 18
+symbol = 'TEST'
+
+[networks.testnet.paratimes.pontusx_test]
+consensus_denomination = 'TEST'
+description = 'Pontus-X Testnet'
+id = '00000000000000000000000000000000000000000000000004a6f9071c007069'
+
+[networks.testnet.paratimes.pontusx_test.denominations]
+[networks.testnet.paratimes.pontusx_test.denominations._]
+decimals = 18
+symbol = 'EUROe'
+
+[networks.testnet.paratimes.pontusx_test.denominations.test]
+decimals = 18
+symbol = 'TEST'
+
+[networks.testnet.paratimes.sapphire]
+consensus_denomination = '_'
+description = ''
+id = '000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c'
+
+[networks.testnet.paratimes.sapphire.denominations]
+[networks.testnet.paratimes.sapphire.denominations._]
+decimals = 18
+symbol = 'TEST'
+
+[wallets]
+default = ''

--- a/examples/paratime-show/show-parameters.in
+++ b/examples/paratime-show/show-parameters.in
@@ -1,0 +1,1 @@
+oasis paratime show parameters

--- a/examples/paratime-show/show-parameters.out
+++ b/examples/paratime-show/show-parameters.out
@@ -1,0 +1,8 @@
+Network:        testnet
+ParaTime:       sapphire
+
+=== ROFL PARAMETERS ===
+  app_create:
+    Amount: 10000000000000000000000
+    Denomination:
+

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/oasisprotocol/deoxysii v0.0.0-20220228165953-2091330c22b7
 	github.com/oasisprotocol/metadata-registry-tools v0.0.0-20220406100644-7e9a2b991920
 	github.com/oasisprotocol/oasis-core/go v0.2403.0
-	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.11.0
+	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.11.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/oasisprotocol/metadata-registry-tools v0.0.0-20220406100644-7e9a2b991
 github.com/oasisprotocol/metadata-registry-tools v0.0.0-20220406100644-7e9a2b991920/go.mod h1:MKr/giwakLyCCjSWh0W9Pbaf7rDD1K96Wr57OhNoUK0=
 github.com/oasisprotocol/oasis-core/go v0.2403.0 h1:jOs3Y0hIDWCOx1y2ZHtj2zzkh36S0nkHQaI77mx3K/o=
 github.com/oasisprotocol/oasis-core/go v0.2403.0/go.mod h1:lUV3T76Ng0QvAXm1loYnVTj3uzAJHwwa29o3QjM/ID8=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.11.0 h1:+0TpEBTMRsRXc4lmLyVZrKWdldolVVpQSYh21LynkAA=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.11.0/go.mod h1:HZcEGQc/XnfJkDTj/bnfHxch3J9AxFKrCU4iQo1w3Gw=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.11.1 h1:CdQ3SznnCVfnSRJszoR10+Nrv3a8nKQFxodZXKpePIo=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.11.1/go.mod h1:HZcEGQc/XnfJkDTj/bnfHxch3J9AxFKrCU4iQo1w3Gw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=


### PR DESCRIPTION
This PR:
- Adds the new `oasis paratime show parameters` subcommand similar to `oasis net show parameters`
```
$ oasis pt show parameters
Network:        testnet
ParaTime:       sapphire

=== ROFL_STAKETHRESHOLDS PARAMETERS ===
  app_create:
    Amount: 10000000000000000000000
    Denomination:

```
- Extends documentation on `oasis network show native-token` output

Fixes https://github.com/oasisprotocol/cli/issues/290, https://github.com/oasisprotocol/docs/issues/978