### PR TITLE
cmd: Change rust target for building ROFL apps

### DIFF
--- a/cmd/rofl/build.go
+++ b/cmd/rofl/build.go
@@ -110,7 +110,7 @@ var (
 
 			// First build for the default target.
 			fmt.Println("Building ELF binary...")
-			elfPath, err := cargo.Build(true, "x86_64-unknown-linux-musl", features)
+			elfPath, err := cargo.Build(true, "x86_64-unknown-linux-gnu", features)
 			if err != nil {
 				cobra.CheckErr(fmt.Errorf("failed to build ELF binary: %w", err))
 			}


### PR DESCRIPTION
Some docker images have changed from being based on Alpine to Ubuntu.