### PR TITLE
feat(cmd/paratime): Print ROFL app id in rofl1 format

### DIFF
--- a/cmd/paratime/show.go
+++ b/cmd/paratime/show.go
@@ -106,6 +106,7 @@ var (
 					rt.ConsensusAccounts,
 					rt.Contracts,
 					rt.Evm,
+					rt.ROFL,
 				}
 
 				blk, err := rt.GetBlock(ctx, blkNum)


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-sdk/issues/2088. It looks like there is no need to add Pretty Print to `oasis-sdk`. The decoder only needs to be included.