### PR TITLE
cmd/paratime/show: Add show events command

### DIFF
--- a/docs/paratime.md
+++ b/docs/paratime.md
@@ -36,7 +36,7 @@ oasis paratime add testnet sapphire2 0000000000000000000000000000000000000000000
 ```
 
 ```
-? Description: 
+? Description:
 ? Denomination symbol: TEST
 ? Denomination decimal places: 18
 ```
@@ -160,6 +160,18 @@ thresholds.
 ![code shell](../examples/paratime-show/show-parameters.in)
 
 ![code](../examples/paratime-show/show-parameters.out)
+
+By passing `--format json`, the output is formatted as JSON.
+
+### `events` {#show-events}
+
+This will return all Paratime events emitted in the block.
+
+Use `--round <round>` to specify the round number.
+
+![code shell](../examples/paratime-show/show-events.in)
+
+![code](../examples/paratime-show/show-events.out)
 
 By passing `--format json`, the output is formatted as JSON.
 

--- a/examples/paratime-show/show-events.in
+++ b/examples/paratime-show/show-events.in
@@ -1,0 +1,1 @@
+oasis paratime show events --round 9399871 --format json

--- a/examples/paratime-show/show-events.out
+++ b/examples/paratime-show/show-events.out
@@ -1,0 +1,80 @@
+[
+  {
+    "code": 1,
+    "data": "gaNidG9VAGIz3RCYb9ltIk8706by6j2XkXGmZGZyb21VAJZQKbOBY+XnA5YUaDhZkNc3y+nsZmFtb3VudIJHCxBZMMJwAEA=",
+    "module": "accounts",
+    "parsed": [
+      {
+        "Transfer": {
+          "from": "oasis1qzt9q2dns937tecrjc2xswzejrtn0jlfas40j7sz",
+          "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+          "amount": {
+            "Amount": "3114200000000000",
+            "Denomination": ""
+          }
+        },
+        "Burn": null,
+        "Mint": null
+      }
+    ],
+    "tx_hash": "c586f05e2103adb953d2287ef22dad0532540bd02481184b5477ba8c38894e62"
+  },
+  {
+    "code": 1,
+    "data": "gqNidG9VAIyCi8jiQIOmvod+yJYxN0GhktyEZGZyb21VACg9qHdJLY0x3unzFR/SHF3dLD+oZmFtb3VudIJIAWNFeMTiZV9Ao2J0b1UAYjPdEJhv2W0iTzvTpvLqPZeRcaZkZnJvbVUAKD2od0ktjTHe6fMVH9IcXd0sP6hmYW1vdW50gkcH3eTk7RgAQA==",
+    "module": "accounts",
+    "parsed": [
+      {
+        "Transfer": {
+          "from": "oasis1qq5rm2rhfykc6vw7a8e3287jr3wa6tpl4qv49gzh",
+          "to": "oasis1qzxg9z7gufqg8f47salv3933xaq6rykusslsq4k7",
+          "amount": {
+            "Amount": "100000001733846367",
+            "Denomination": ""
+          }
+        },
+        "Burn": null,
+        "Mint": null
+      },
+      {
+        "Transfer": {
+          "from": "oasis1qq5rm2rhfykc6vw7a8e3287jr3wa6tpl4qv49gzh",
+          "to": "oasis1qp3r8hgsnphajmfzfuaa8fhjag7e0yt35cjxq0u4",
+          "amount": {
+            "Amount": "2214300000000000",
+            "Denomination": ""
+          }
+        },
+        "Burn": null,
+        "Mint": null
+      }
+    ],
+    "tx_hash": "de7e52e94f4614ec0b0de47971abc12d5070278e9401c2466ec5664a71bdc57d"
+  },
+  {
+    "code": 1,
+    "data": "gaFmYW1vdW50GXmm",
+    "module": "core",
+    "parsed": [
+      {
+        "GasUsed": {
+          "amount": 31142
+        }
+      }
+    ],
+    "tx_hash": "c586f05e2103adb953d2287ef22dad0532540bd02481184b5477ba8c38894e62"
+  },
+  {
+    "code": 1,
+    "data": "gaFmYW1vdW50GVZ/",
+    "module": "core",
+    "parsed": [
+      {
+        "GasUsed": {
+          "amount": 22143
+        }
+      }
+    ],
+    "tx_hash": "de7e52e94f4614ec0b0de47971abc12d5070278e9401c2466ec5664a71bdc57d"
+  }
+]


### PR DESCRIPTION
Useful for easily fetching all events in a paratime block. The existing `paratime show` displays only block events (when querying info about a block) or events of a single transaction (when querying info about a transaction within a block).

Alternative would be updating the existing `paratime show <round>` to return all events emitted in a block, but the number of events could be large, so it might bloat the output for someone not really interested about this.