### PR TITLE
docs: Fix config path from Roaming to Local on Windows

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,7 +34,7 @@ configure all [ParaTimes supported by the Oasis Foundation][paratimes].
 The configuration folder of Oasis CLI is located:
 
 - on Windows:
-  - `%USERPROFILE%\AppData\Roaming\oasis\`
+  - `%USERPROFILE%\AppData\Local\oasis\`
 - on macOS:
   - `/Users/$USER/Library/Application Support/oasis/`
 - on Linux:


### PR DESCRIPTION
When testing #344 I realized the configuration directory is Local, not Roaming by default. Tested on Win10 64-bit.