### PR TITLE
feat(cmd/rofl): Store artifacts on init for reproducible builds

### DIFF
--- a/build/rofl/artifacts.go
+++ b/build/rofl/artifacts.go
@@ -13,7 +13,7 @@ var LatestContainerArtifacts = ArtifactsConfig{
 	Kernel:   "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/stage1.bin#539f25c66a27b2ca3c6b4d3333b88c64e531fcc96776c37a12c9ce06dd7fbac9",
 	Stage2:   "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/stage2-podman.tar.bz2#827531546f3db6b0945ece7ddab4e10d648eaa3ba1c146b7889d7cb9cbf0b507",
 	Container: ContainerArtifactsConfig{
-		Runtime: "https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.3.3/rofl-containers#b7f025e3bb844a4ce044fa3a2503f6854e5e2d2d5ec22be919c582e57cf5d6ab",
+		Runtime: "https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.3.4/rofl-containers#d6a055b2e88e1f321e3ab1f73046444e24df9d8925d13cc6b8230de9a81e5c41",
 		Compose: "compose.yaml",
 	},
 }

--- a/build/rofl/artifacts.go
+++ b/build/rofl/artifacts.go
@@ -1,0 +1,19 @@
+package rofl
+
+// LatestBasicArtifacts are the latest TDX ROFL basic app artifacts.
+var LatestBasicArtifacts = ArtifactsConfig{
+	Firmware: "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/ovmf.tdx.fd#db47100a7d6a0c1f6983be224137c3f8d7cb09b63bb1c7a5ee7829d8e994a42f",
+	Kernel:   "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/stage1.bin#539f25c66a27b2ca3c6b4d3333b88c64e531fcc96776c37a12c9ce06dd7fbac9",
+	Stage2:   "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/stage2-basic.tar.bz2#72c84d2566959799fdd98fae08c143a8572a5a09ee426be376f9a8bbd1675f2b",
+}
+
+// LatestContainerArtifacts are the latest TDX container app artifacts.
+var LatestContainerArtifacts = ArtifactsConfig{
+	Firmware: "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/ovmf.tdx.fd#db47100a7d6a0c1f6983be224137c3f8d7cb09b63bb1c7a5ee7829d8e994a42f",
+	Kernel:   "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/stage1.bin#539f25c66a27b2ca3c6b4d3333b88c64e531fcc96776c37a12c9ce06dd7fbac9",
+	Stage2:   "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/stage2-podman.tar.bz2#827531546f3db6b0945ece7ddab4e10d648eaa3ba1c146b7889d7cb9cbf0b507",
+	Container: ContainerArtifactsConfig{
+		Runtime: "https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.3.3/rofl-containers#b7f025e3bb844a4ce044fa3a2503f6854e5e2d2d5ec22be919c582e57cf5d6ab",
+		Compose: "compose.yaml",
+	},
+}

--- a/cmd/rofl/build/container.go
+++ b/cmd/rofl/build/container.go
@@ -12,17 +12,6 @@ import (
 	"github.com/oasisprotocol/cli/cmd/common"
 )
 
-const (
-	artifactContainerRuntime = "rofl-container runtime"
-	artifactContainerCompose = "compose.yaml"
-
-	defaultContainerStage2TemplateURI = "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.3.3/stage2-podman.tar.bz2#827531546f3db6b0945ece7ddab4e10d648eaa3ba1c146b7889d7cb9cbf0b507"
-
-	defaultContainerRuntimeURI = "https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.3.3/rofl-containers#b7f025e3bb844a4ce044fa3a2503f6854e5e2d2d5ec22be919c582e57cf5d6ab"
-
-	defaultContainerComposeURI = "compose.yaml"
-)
-
 // tdxBuildContainer builds a TDX-based container ROFL app.
 func tdxBuildContainer(
 	tmpDir string,
@@ -33,20 +22,7 @@ func tdxBuildContainer(
 ) error {
 	fmt.Println("Building a container-based TDX ROFL application...")
 
-	tdxStage2TemplateURI = defaultContainerStage2TemplateURI
-
-	wantedArtifacts := tdxGetDefaultArtifacts()
-	wantedArtifacts = append(wantedArtifacts,
-		&artifact{
-			kind: artifactContainerRuntime,
-			uri:  defaultContainerRuntimeURI,
-		},
-		&artifact{
-			kind: artifactContainerCompose,
-			uri:  defaultContainerComposeURI,
-		},
-	)
-	tdxOverrideArtifacts(manifest, wantedArtifacts)
+	wantedArtifacts := tdxWantedArtifacts(manifest, buildRofl.LatestContainerArtifacts)
 	artifacts := tdxFetchArtifacts(wantedArtifacts)
 
 	// Validate compose file.

--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -87,6 +87,9 @@ var (
 			height, err := common.GetActualHeight(ctx, conn.Consensus())
 			cobra.CheckErr(err)
 
+			blk, err := conn.Consensus().GetBlock(ctx, height)
+			cobra.CheckErr(err)
+
 			// Determine debug mode.
 			var debugMode bool
 			params, err := conn.Consensus().Registry().ConsensusParameters(ctx, height)
@@ -116,6 +119,7 @@ var (
 				},
 				TrustRoot: &buildRofl.TrustRootConfig{
 					Height: uint64(height),
+					Hash:   blk.Hash.Hex(),
 				},
 			}
 			manifest := buildRofl.Manifest{
@@ -149,13 +153,21 @@ var (
 			fmt.Printf("  Debug:    %v\n", deployment.Debug)
 			fmt.Printf("  Admin:    %s\n", deployment.Admin)
 
-			// For container app kind also create an en empty compose.yaml file if it doesn't exist.
-			if appKind == buildRofl.AppKindContainer {
+			switch appKind {
+			case buildRofl.AppKindRaw:
+				artifacts := buildRofl.LatestBasicArtifacts // Copy.
+				manifest.Artifacts = &artifacts
+			case buildRofl.AppKindContainer:
+				// For container app kind also create an en empty compose.yaml file if it doesn't exist.
 				var f *os.File
 				f, err = os.OpenFile("compose.yaml", os.O_RDONLY|os.O_CREATE, 0o644)
 				if err == nil {
 					f.Close()
 				}
+
+				artifacts := buildRofl.LatestContainerArtifacts // Copy.
+				manifest.Artifacts = &artifacts
+			default:
 			}
 
 			// Serialize manifest and write it to file.

--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -153,20 +153,24 @@ var (
 			fmt.Printf("  Debug:    %v\n", deployment.Debug)
 			fmt.Printf("  Admin:    %s\n", deployment.Admin)
 
-			switch appKind {
-			case buildRofl.AppKindRaw:
-				artifacts := buildRofl.LatestBasicArtifacts // Copy.
-				manifest.Artifacts = &artifacts
-			case buildRofl.AppKindContainer:
-				// For container app kind also create an en empty compose.yaml file if it doesn't exist.
-				var f *os.File
-				f, err = os.OpenFile("compose.yaml", os.O_RDONLY|os.O_CREATE, 0o644)
-				if err == nil {
-					f.Close()
-				}
+			switch manifest.TEE {
+			case buildRofl.TEETypeTDX:
+				switch appKind {
+				case buildRofl.AppKindRaw:
+					artifacts := buildRofl.LatestBasicArtifacts // Copy.
+					manifest.Artifacts = &artifacts
+				case buildRofl.AppKindContainer:
+					// For container app kind also create an en empty compose.yaml file if it doesn't exist.
+					var f *os.File
+					f, err = os.OpenFile("compose.yaml", os.O_RDONLY|os.O_CREATE, 0o644)
+					if err == nil {
+						f.Close()
+					}
 
-				artifacts := buildRofl.LatestContainerArtifacts // Copy.
-				manifest.Artifacts = &artifacts
+					artifacts := buildRofl.LatestContainerArtifacts // Copy.
+					manifest.Artifacts = &artifacts
+				default:
+				}
 			default:
 			}
 
@@ -471,6 +475,37 @@ var (
 				}
 			} else {
 				fmt.Println("No registered app instances.")
+			}
+		},
+	}
+
+	upgradeCmd = &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade all artifacts to their latest default versions",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			cfg := cliConfig.Global()
+			npa := common.GetNPASelection(cfg)
+
+			manifest, _ := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, false)
+
+			switch manifest.TEE {
+			case buildRofl.TEETypeTDX:
+				switch manifest.Kind {
+				case buildRofl.AppKindRaw:
+					artifacts := buildRofl.LatestBasicArtifacts // Copy.
+					manifest.Artifacts = &artifacts
+				case buildRofl.AppKindContainer:
+					artifacts := buildRofl.LatestContainerArtifacts // Copy.
+					manifest.Artifacts = &artifacts
+				default:
+				}
+			default:
+			}
+
+			// Update manifest.
+			if err := manifest.Save(); err != nil {
+				cobra.CheckErr(fmt.Errorf("failed to update manifest: %w", err))
 			}
 		},
 	}

--- a/cmd/rofl/rofl.go
+++ b/cmd/rofl/rofl.go
@@ -22,4 +22,5 @@ func init() {
 	Cmd.AddCommand(build.Cmd)
 	Cmd.AddCommand(identityCmd)
 	Cmd.AddCommand(secretCmd)
+	Cmd.AddCommand(upgradeCmd)
 }


### PR DESCRIPTION
Also add `rofl artifacts-upgrade` for easy upgrades and bump default container runtime to rofl-containers v0.3.4.