### PR TITLE
cmd/rofl/build: Update manifest by default

### DIFF
--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -243,7 +243,7 @@ var (
 				cobra.CheckErr(fmt.Errorf("failed to update manifest: %w", err))
 			}
 
-			fmt.Printf("Run `oasis rofl build --update-manifest` to build your ROFL app.\n")
+			fmt.Printf("Run `oasis rofl build` to build your ROFL app.\n")
 		},
 	}
 

--- a/docs/rofl.md
+++ b/docs/rofl.md
@@ -77,9 +77,6 @@ Container (ORC) bundle.
 
 Additionally, the following flags are available:
 
-- `--update-manifest` updates the enclave identity in the app manifest with the
-  identity of the locally built app.
-
 - `--output` the filename of the output ORC bundle. Defaults to the pattern
   `<name>.<deployment>.orc` where `<name>` is the app name from the manifest and
   `<deployment>` is the deployment name from the manifest.
@@ -87,6 +84,9 @@ Additionally, the following flags are available:
 - `--verify` also verifies the locally built enclave identity against the
   identity that is currently defined in the manifest and also against the
   identity that is currently set in the on-chain policy.
+
+- `--no-update-manifest` do not update the enclave identity stored in the app
+  manifest.
 
 :::info
 


### PR DESCRIPTION
Running `oasis rofl build` now updates the manifest by default. Pass `--no-update-manifest` if you really don't want to update it. Mark `--update-manifest` as deprecated until all the examples and demos are updated to avoid breaking compatibility.