### PR TITLE
cmd: Show default config path for --config global flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -55,13 +54,12 @@ func initConfig() {
 		// Use config file from the flag.
 		v.SetConfigFile(cfgFile)
 	} else {
-		const configFilename = "cli.toml"
 		configDir := config.DefaultDirectory()
-		configPath := filepath.Join(configDir, configFilename)
+		configPath := config.DefaultPath()
 
 		v.AddConfigPath(configDir)
 		v.SetConfigType("toml")
-		v.SetConfigName(configFilename)
+		v.SetConfigName(config.DefaultFilename())
 
 		// Ensure the configuration file exists.
 		_ = os.MkdirAll(configDir, 0o700)
@@ -96,7 +94,9 @@ func init() {
 
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file to use")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
+		fmt.Sprintf("config file to use (instead of the default %s)", config.DefaultPath()),
+	)
 
 	rootCmd.AddCommand(network.Cmd)
 	rootCmd.AddCommand(paratime.Cmd)

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,18 @@ func DefaultDirectory() string {
 	return filepath.Join(xdg.ConfigHome, "oasis")
 }
 
+// DefaultFilename returns the default configuration filename.
+func DefaultFilename() string {
+	return "cli.toml"
+}
+
+// DefaultPath returns the path to the default configuration file.
+func DefaultPath() string {
+	configDir := DefaultDirectory()
+	configPath := filepath.Join(configDir, DefaultFilename())
+	return configPath
+}
+
 // Global returns the global configuration structure.
 func Global() *Config {
 	return &global

--- a/examples/setup/first-run.out
+++ b/examples/setup/first-run.out
@@ -16,7 +16,7 @@ Available Commands:
   wallet      Manage accounts in the local wallet
 
 Flags:
-      --config string   config file to use
+      --config string   config file to use (instead of the default ~/.config/oasis/cli.toml)
   -h, --help            help for oasis
   -v, --version         version for oasis
 


### PR DESCRIPTION
Sometimes users could struggle to find where the config file is located (especially on MacOS). It is useful if we show that info as part of the help message for the global `--config` flag. In the future, it would also be nice to have something like `oasis config set/get/reset`.