### PR TITLE
cmd/rofl/init: Detect rofl-compose.yaml as well if it exists

### DIFF
--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -675,7 +675,7 @@ var (
 
 // detectAndCreateComposeFile detects the existing compose.yaml-like file and returns its filename. Otherwise, creates an empty default compose.yaml.
 func detectOrCreateComposeFile() string {
-	for _, filename := range []string{"docker-compose.yaml", "docker-compose.yml", "compose.yml"} {
+	for _, filename := range []string{"rofl-compose.yaml", "rofl-compose.yml", "docker-compose.yaml", "docker-compose.yml", "compose.yml"} {
 		if _, err := os.Stat(filename); err == nil {
 			return filename
 		}


### PR DESCRIPTION
In some projects, we needed to separate between the generic `compose.yaml` files and ROFL-tailored compose files (e.g. how env variables are populated). In this case we named it `rofl-compose.yaml`. When running `oasis rofl init`, autodetect it and use it, if it exists.