### PR TITLE
cmd/rofl/machine: Rename terminate/cancel -> stop/remove

### DIFF
--- a/cmd/rofl/machine/machine.go
+++ b/cmd/rofl/machine/machine.go
@@ -13,7 +13,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(showCmd)
 	Cmd.AddCommand(restartCmd)
-	Cmd.AddCommand(terminateCmd)
-	Cmd.AddCommand(cancelCmd)
+	Cmd.AddCommand(stopCmd)
+	Cmd.AddCommand(removeCmd)
 	Cmd.AddCommand(topUpCmd)
 }

--- a/cmd/rofl/machine/mgmt.go
+++ b/cmd/rofl/machine/mgmt.go
@@ -161,7 +161,7 @@ var (
 
 	restartCmd = &cobra.Command{
 		Use:   "restart [<machine-name>]",
-		Short: "Restart a machine",
+		Short: "Restart a running machine or start a stopped one",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			queueCommand(
@@ -175,10 +175,11 @@ var (
 		},
 	}
 
-	terminateCmd = &cobra.Command{
-		Use:   "terminate [<machine-name>]",
-		Short: "Terminate a machine",
-		Args:  cobra.MaximumNArgs(1),
+	stopCmd = &cobra.Command{
+		Use:     "stop [<machine-name>]",
+		Short:   "Stop a machine",
+		Aliases: []string{"terminate"},
+		Args:    cobra.MaximumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			queueCommand(
 				args,
@@ -191,10 +192,11 @@ var (
 		},
 	}
 
-	cancelCmd = &cobra.Command{
-		Use:   "cancel [<machine-name>]",
-		Short: "Cancel a machine",
-		Args:  cobra.MaximumNArgs(1),
+	removeCmd = &cobra.Command{
+		Use:     "remove [<machine-name>]",
+		Short:   "Cancel rental and remove the machine",
+		Aliases: []string{"cancel", "rm"},
+		Args:    cobra.MaximumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			cfg := cliConfig.Global()
 			npa := common.GetNPASelection(cfg)
@@ -223,7 +225,7 @@ var (
 
 			fmt.Printf("Using provider:     %s (%s)\n", machine.Provider, providerAddr)
 			fmt.Printf("Canceling machine:  %s [%s]\n", machineName, machine.ID)
-			fmt.Printf("WARNING: Canceling a machine will permanently destroy it!\n")
+			fmt.Printf("WARNING: Canceling a machine will permanently destroy it including any persistent storage!\n")
 
 			// Prepare transaction.
 			tx := roflmarket.NewInstanceCancelTx(nil, &roflmarket.InstanceCancel{
@@ -239,7 +241,7 @@ var (
 				return
 			}
 
-			fmt.Printf("Machine cancelled.\n")
+			fmt.Printf("Machine removed.\n")
 
 			// Update manifest to clear the machine ID as it has been cancelled.
 			machine.ID = ""
@@ -429,14 +431,14 @@ func init() {
 	restartCmd.Flags().AddFlagSet(deploymentFlags)
 	restartCmd.Flags().AddFlagSet(wipeFlags)
 
-	terminateCmd.Flags().AddFlagSet(common.SelectorFlags)
-	terminateCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	terminateCmd.Flags().AddFlagSet(deploymentFlags)
-	terminateCmd.Flags().AddFlagSet(wipeFlags)
+	stopCmd.Flags().AddFlagSet(common.SelectorFlags)
+	stopCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
+	stopCmd.Flags().AddFlagSet(deploymentFlags)
+	stopCmd.Flags().AddFlagSet(wipeFlags)
 
-	cancelCmd.Flags().AddFlagSet(common.SelectorFlags)
-	cancelCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	cancelCmd.Flags().AddFlagSet(deploymentFlags)
+	removeCmd.Flags().AddFlagSet(common.SelectorFlags)
+	removeCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
+	removeCmd.Flags().AddFlagSet(deploymentFlags)
 
 	topUpCmd.Flags().AddFlagSet(common.SelectorFlags)
 	topUpCmd.Flags().AddFlagSet(common.RuntimeTxFlags)


### PR DESCRIPTION
This PR renames:
1. `oasis rofl machine terminate` -> `oasis rofl machine stop`
2. `oasis rofl machine cancel` -> `oasis rofl machine remove`

It keeps old "terminate" and "cancel" subcommands as aliases.

## Rationale

1. The "terminate" term may also associate with "terminate your subscription", which is not the case. The "stop" term is also more consistent with Docker's "start/stop/restart" terminology and also with `oasis rofl machine restart`.
2. The "cancel" term may be a bit too soft since it cancels your subscription and destroys the machine. I'd prefer to call this "remove" for consistency with other "add/remove" subcommands.