### PR TITLE
cmd&build: Push ORCs to Oasis-managed ROFL registry by default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,6 +80,7 @@ linters-settings:
           - github.com/opencontainers/image-spec/specs-go/v1
           - oras.land/oras-go/v2
           - github.com/wI2L/jsondiff
+          - github.com/google/uuid
   exhaustive:
     # Switch statements are to be considered exhaustive if a 'default' case is
     # present, even if all enum members aren't listed in the switch.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/foxboron/go-uefi v0.0.0-20241017190036-fab4fdf2f2f3
 	github.com/github/go-spdx/v2 v2.3.2
+	github.com/google/uuid v1.6.0
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a


### PR DESCRIPTION
Previously, the CLI required configuring an OCI repository manually when using `oasis rofl deploy`. The changes here simplify this by introducing a default Oasis-managed OCI registry for pushing ROFL ORCs.