### PR TITLE
rofl deploy: Set default provider address, detect term and take the first offer

### DIFF
--- a/cmd/rofl/deploy.go
+++ b/cmd/rofl/deploy.go
@@ -295,7 +295,8 @@ func showProviderOffer(offer *roflmarket.Offer) {
 
 func init() {
 	providerFlags := flag.NewFlagSet("", flag.ContinueOnError)
-	providerFlags.StringVar(&deployProvider, "provider", "", "set the provider address")
+	// Default to Testnet playground provider.
+	providerFlags.StringVar(&deployProvider, "provider", "oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz", "set the provider address")
 	providerFlags.StringVar(&deployOffer, "offer", "", "set the provider's offer identifier")
 	providerFlags.StringVar(&deployMachine, "machine", buildRofl.DefaultMachineName, "machine to deploy into")
 	providerFlags.StringVar(&deployTerm, "term", roflCommon.TermMonth, "term to pay for in advance")


### PR DESCRIPTION
This PR simplifies flow for first-time developers building ROFL on Testnet:
- detects the term (month, day, year) based on the selected offer (#441)
- sets the default ROFL provider to `oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz`, if none provided (Oasis foundation-managed Testnet node)
- if no offer provided, take the first one instead of throwing the error
- adds `--show-offers` for listing offers and quit

Fixes #441 