### PR TITLE
Clear any previously set errors for Docker env

### DIFF
--- a/build/env/env.go
+++ b/build/env/env.go
@@ -100,6 +100,7 @@ func (de *DockerEnv) AddDirectory(path string) {
 
 // WrapCommand implements ExecEnv.
 func (de *DockerEnv) WrapCommand(cmd *exec.Cmd) error {
+	cmd.Err = nil // May be set by a previous exec.Command invocation.
 	origArgs := cmd.Args
 
 	var err error


### PR DESCRIPTION
This could previously cause an incorrect error to be propagated when the host did not have the given binary installed.