### PR TITLE
cmd/rofl/deploy: Fix --provider behaviour

### DIFF
--- a/build/rofl/provider/defaults.go
+++ b/build/rofl/provider/defaults.go
@@ -1,8 +1,20 @@
 package provider
 
-// DefaultSchedulerApp contains the default scheduler app IDs for each network/paratime.
-var DefaultSchedulerApp = map[string]map[string]string{
-	"testnet": {
-		"sapphire": "rofl1qrqw99h0f7az3hwt2cl7yeew3wtz0fxunu7luyfg",
+import "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+
+// RoflServices contains per network/ParaTime default ROFL services.
+type RoflServices struct {
+	// Scheduler is a ROFL app ID of the preferred scheduler app.
+	Scheduler string
+
+	// Provider is the address of the preferred provider.
+	Provider string
+}
+
+// DefaultRoflServices contains default built-in ROFL services for all supported networks/ParaTimes.
+var DefaultRoflServices = map[string]RoflServices{
+	config.DefaultNetworks.All["testnet"].ParaTimes.All["sapphire"].ID: {
+		Scheduler: "rofl1qrqw99h0f7az3hwt2cl7yeew3wtz0fxunu7luyfg",
+		Provider:  "oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz",
 	},
 }

--- a/cmd/rofl/provider/mgmt.go
+++ b/cmd/rofl/provider/mgmt.go
@@ -36,8 +36,8 @@ var (
 			}
 
 			var schedulerApp rofl.AppID
-			rawSchedulerApp, ok := provider.DefaultSchedulerApp[npa.NetworkName][npa.ParaTimeName]
-			if ok {
+			rawSchedulerApp := provider.DefaultRoflServices[npa.ParaTime.ID].Scheduler
+			if rawSchedulerApp != "" {
 				err := schedulerApp.UnmarshalText([]byte(rawSchedulerApp))
 				cobra.CheckErr(err)
 			}


### PR DESCRIPTION
This PR:
- fixes regression introduced by https://github.com/oasisprotocol/cli/pull/447/commits/ccc43dbb6fd331ea7f41ab6f58b16ac7a8a9967d . You couldn't deploy a new version of ROFL on the existing machine, because --provider parameter wasn't empty anymore.
- uses the Testnet provider only if Testnet Sapphire ParaTime is selected
- fixes CLI complaining, if you wanted to deploy to an existing machine that matches the `--provider` name.