### PR TITLE
fix(cmd/rofl): Add missing term flags to top-up command

### DIFF
--- a/cmd/rofl/machine/mgmt.go
+++ b/cmd/rofl/machine/mgmt.go
@@ -443,4 +443,5 @@ func init() {
 	topUpCmd.Flags().AddFlagSet(common.SelectorFlags)
 	topUpCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
 	topUpCmd.Flags().AddFlagSet(deploymentFlags)
+	topUpCmd.Flags().AddFlagSet(topUpFlags)
 }


### PR DESCRIPTION
Fixes #459 