### PR TITLE
cmd: Also remove the deployment from rofl.yaml when removing app

### DIFF
--- a/docs/rofl.md
+++ b/docs/rofl.md
@@ -118,6 +118,13 @@ Run `rofl remove` to deregister your ROFL app:
 The deposit required to register the ROFL app will be returned to the current
 administrator account.
 
+:::danger Secrets will be permanently lost
+
+All secrets stored on-chain will be permanently lost when the ROFL app will be
+deregistered.
+
+:::
+
 ## Show ROFL information {#show}
 
 Run `rofl show` to obtain the information from the network on the ROFL admin

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,8 +2,8 @@
 
 ## Download and Run
 
-Download the latest release [here][cli-releases] and extract it to your
-favorite application folder.
+Download the latest release from our [GitHub repository][cli-releases] and
+extract it to your favorite application folder.
 
 :::info
 

--- a/examples/rofl/remove.out.static
+++ b/examples/rofl/remove.out.static
@@ -1,3 +1,8 @@
+WARNING: Removing this ROFL app will DEREGISTER it, ERASE any on-chain secrets and local configuration!
+WARNING: THIS ACTION IS IRREVERSIBLE!
+? Remove ROFL app 'rofl1qzd82n99vtwesvcqjfyur4tcm45varz2due7s635' deployed on network 'testnet' Yes
+Unlock your account.
+? Passphrase:
 You are about to sign the following transaction:
 Format: plain
 Method: rofl.Remove


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/cli/issues/461 by removing the corresponding deployment section from `rofl.yaml` when removing the ROFL app.

Also, a warning message is now shown:

```
$ oasis rofl remove
WARNING: Removing this ROFL app will DEREGISTER it, ERASE any on-chain secrets and local configuration!
WARNING: THIS ACTION IS IRREVERSIBLE!
? Remove ROFL app 'rofl1qpjsc3qplf2szw7w3rpzrpq5rqvzv4q5x5j23msu' deployed on network 'testnet' (y/N)
```