### PR TITLE
feat(cmd/rofl): Add support for machine logs

### DIFF
--- a/build/rofl/scheduler/auth.go
+++ b/build/rofl/scheduler/auth.go
@@ -1,0 +1,72 @@
+package scheduler
+
+import (
+	"encoding/base64"
+	"time"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
+
+// StdAuthContextBase is the base authentication context.
+const StdAuthContextBase = "rofl-scheduler/auth: v1"
+
+// AuthLoginRequest is the request to login.
+type AuthLoginRequest struct {
+	Method string `json:"method"`
+	Data   any    `json:"data"`
+}
+
+// AuthLoginResponse is the response from the login request.
+type AuthLoginResponse struct {
+	Token  string `json:"token"`
+	Expiry uint64 `json:"expiry"`
+}
+
+// StdAuthLoginRequest is the body for the standard authentication method.
+type StdAuthLoginRequest struct {
+	Body      string `json:"body"`
+	Signature string `json:"signature"`
+}
+
+// StdAuthBody is the standard authentication body.
+type StdAuthBody struct {
+	Version   uint16          `json:"v"`
+	Domain    string          `json:"domain"`
+	Provider  types.Address   `json:"provider"`
+	Signer    types.PublicKey `json:"signer"`
+	Nonce     string          `json:"nonce"`
+	NotBefore uint64          `json:"not_before"`
+	NotAfter  uint64          `json:"not_after"`
+}
+
+// SignLogin creates a new login request for the given provider and signs it.
+func SignLogin(sigCtx signature.Context, signer signature.Signer, domain string, provider types.Address) (*AuthLoginRequest, error) {
+	notBefore := time.Now().Add(-10 * time.Second) // Allow for some time drift.
+	notAfter := time.Now().Add(30 * time.Second)   // Short expiry, just needed for login.
+
+	body := StdAuthBody{
+		Version:   1,
+		Domain:    domain,
+		Provider:  provider,
+		Signer:    types.PublicKey{PublicKey: signer.Public()},
+		Nonce:     "",
+		NotBefore: uint64(notBefore.Unix()), //nolint: gosec
+		NotAfter:  uint64(notAfter.Unix()),  //nolint: gosec
+	}
+	rawBody := cbor.Marshal(body)
+	sig, err := signer.ContextSign(sigCtx, rawBody)
+	if err != nil {
+		return nil, err
+	}
+
+	rq := &AuthLoginRequest{
+		Method: "std",
+		Data: StdAuthLoginRequest{
+			Body:      base64.StdEncoding.EncodeToString(rawBody),
+			Signature: base64.StdEncoding.EncodeToString(sig),
+		},
+	}
+	return rq, nil
+}

--- a/build/rofl/scheduler/client.go
+++ b/build/rofl/scheduler/client.go
@@ -1,0 +1,139 @@
+package scheduler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rofl"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/roflmarket"
+)
+
+const (
+	apiURIAuthLogin = "/rofl-scheduler/v1/auth/login"
+	apiURILogsGet   = "/rofl-scheduler/v1/logs/get"
+)
+
+// Client is a ROFL scheduler API endpoint client.
+type Client struct {
+	mu sync.Mutex
+
+	baseURI *url.URL
+	hc      *http.Client
+
+	authToken  string
+	authExpiry time.Time
+}
+
+// NewClient creates a new ROFL scheduler API endpoint client.
+func NewClient(dsc *rofl.Registration) (*Client, error) {
+	baseURIRaw, ok := dsc.Metadata[MetadataKeySchedulerAPI]
+	if !ok {
+		return nil, fmt.Errorf("scheduler does not publish an API endpoint")
+	}
+	baseURI, err := url.Parse(baseURIRaw)
+	if err != nil {
+		return nil, fmt.Errorf("malformed API endpoint: %w", err)
+	}
+
+	hc, err := NewHTTPClient(dsc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		baseURI: baseURI,
+		hc:      hc,
+	}, nil
+}
+
+// Host is the hostname.
+func (c *Client) Host() string {
+	return c.baseURI.Host
+}
+
+// Login authenticates to the scheduler using the given login request.
+func (c *Client) Login(ctx context.Context, req *AuthLoginRequest) error {
+	c.mu.Lock()
+	authToken := c.authToken
+	authExpiry := c.authExpiry
+	c.mu.Unlock()
+
+	if authToken != "" && time.Now().Before(authExpiry) {
+		return nil
+	}
+
+	var rsp AuthLoginResponse
+	if err := c.post(ctx, apiURIAuthLogin, req, &rsp); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.authToken = rsp.Token
+	c.authExpiry = time.Unix(int64(rsp.Expiry), 0) //nolint: gosec
+	return nil
+}
+
+// LogsGet fetches logs for the given machine.
+func (c *Client) LogsGet(ctx context.Context, machineID roflmarket.InstanceID, since time.Time) ([]string, error) {
+	hexInstanceID, err := machineID.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+
+	req := LogsGetRequest{
+		InstanceID: string(hexInstanceID),
+		Since:      uint64(since.Unix()), //nolint: gosec
+	}
+	var rsp LogsGetResponse
+	if err = c.post(ctx, apiURILogsGet, req, &rsp); err != nil {
+		return nil, err
+	}
+	return rsp.Logs, nil
+}
+
+func (c *Client) post(ctx context.Context, path string, request, response any) error {
+	encRequest, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	url := c.baseURI.JoinPath(path).String()
+	rq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(encRequest))
+	if err != nil {
+		return err
+	}
+
+	rq.Header.Add("Content-Type", "application/json")
+
+	c.mu.Lock()
+	if c.authToken != "" {
+		rq.Header.Add("Authorization", "Bearer "+c.authToken)
+	}
+	c.mu.Unlock()
+
+	rsp, err := c.hc.Do(rq)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	data, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		return err
+	}
+	switch rsp.StatusCode {
+	case http.StatusOK:
+		return json.Unmarshal(data, response)
+	default:
+		return fmt.Errorf("unexpected response from server: %s (%s)", rsp.Status, string(data))
+	}
+}

--- a/build/rofl/scheduler/commands.go
+++ b/build/rofl/scheduler/commands.go
@@ -40,3 +40,20 @@ type TerminateRequest struct {
 	// WipeStorage is a flag indicating whether persistent storage should be wiped.
 	WipeStorage bool `json:"wipe_storage"`
 }
+
+// LogsGetRequest is a request to get logs.
+type LogsGetRequest struct {
+	// InstanceID is the instance identifier.
+	InstanceID string `json:"instance_id"`
+	// ComponentID is the optional component identifier.
+	ComponentID string `json:"component_id,omitempty"`
+	// Since is an optional UNIX timestamp to filter log entries by. Only entries with higher
+	// timestamps will be returned.
+	Since uint64 `json:"since,omitempty"`
+}
+
+// LogsGetResponse is the response from the LogsGet request.
+type LogsGetResponse struct {
+	// Logs are the resulting log lines.
+	Logs []string `json:"logs"`
+}

--- a/build/rofl/scheduler/metadata.go
+++ b/build/rofl/scheduler/metadata.go
@@ -1,0 +1,12 @@
+package scheduler
+
+const (
+	// MetadataKeyError is the name of the metadata key that stores the error message.
+	MetadataKeyError = "net.oasis.error"
+	// MetadataKeySchedulerRAK is the name of the metadata key that stores the scheduler RAK.
+	MetadataKeySchedulerRAK = "net.oasis.scheduler.rak"
+	// MetadataKeyTLSPk is the name of the metadata key that stores the TLS public key.
+	MetadataKeyTLSPk = "net.oasis.tls.pk"
+	// MetadataKeySchedulerAPI is the name of the metadata key that stores the API endpoint address.
+	MetadataKeySchedulerAPI = "net.oasis.scheduler.api"
+)

--- a/build/rofl/scheduler/tls.go
+++ b/build/rofl/scheduler/tls.go
@@ -1,0 +1,49 @@
+package scheduler
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rofl"
+)
+
+// NewHTTPClient creates an HTTP client to communicate with the given scheduler.
+func NewHTTPClient(dsc *rofl.Registration) (*http.Client, error) {
+	schedulerTLSPk, ok := dsc.Metadata[MetadataKeyTLSPk]
+	if !ok {
+		return nil, fmt.Errorf("scheduler does not publish its TLS public key")
+	}
+	expectedSubjectPublicKeyInfo, err := base64.StdEncoding.DecodeString(schedulerTLSPk)
+	if err != nil {
+		return nil, fmt.Errorf("malformed scheduler TLS public key: %w", err)
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+				if len(rawCerts) == 0 {
+					return fmt.Errorf("server did not send a certificate")
+				}
+
+				cert, err := x509.ParseCertificate(rawCerts[0])
+				if err != nil {
+					return fmt.Errorf("bad X509 certificate: %w", err)
+				}
+
+				if !bytes.Equal(cert.RawSubjectPublicKeyInfo, expectedSubjectPublicKeyInfo) {
+					return fmt.Errorf("server certificate public key does not match expected value")
+				}
+				return nil
+			},
+		},
+	}
+	client := &http.Client{
+		Transport: transport,
+	}
+	return client, nil
+}

--- a/cmd/rofl/machine/logs.go
+++ b/cmd/rofl/machine/logs.go
@@ -1,0 +1,99 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/ed25519"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
+	buildRofl "github.com/oasisprotocol/cli/build/rofl"
+	"github.com/oasisprotocol/cli/build/rofl/scheduler"
+	"github.com/oasisprotocol/cli/cmd/common"
+	roflCommon "github.com/oasisprotocol/cli/cmd/rofl/common"
+	cliConfig "github.com/oasisprotocol/cli/config"
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs [<machine-name>]",
+	Short: "Show logs from the given machine",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(_ *cobra.Command, args []string) {
+		cfg := cliConfig.Global()
+		npa := common.GetNPASelection(cfg)
+
+		_, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+			NeedAppID: true,
+			NeedAdmin: false,
+		})
+
+		machine, _, machineID := resolveMachine(args, deployment)
+
+		// Establish connection with the target network.
+		ctx := context.Background()
+		conn, err := connection.Connect(ctx, npa.Network)
+		cobra.CheckErr(err)
+
+		// Resolve provider address.
+		providerAddr, _, err := common.ResolveLocalAccountOrAddress(npa.Network, machine.Provider)
+		if err != nil {
+			cobra.CheckErr(fmt.Sprintf("Invalid provider address: %s", err))
+		}
+
+		providerDsc, err := conn.Runtime(npa.ParaTime).ROFLMarket.Provider(ctx, client.RoundLatest, *providerAddr)
+		cobra.CheckErr(err)
+
+		insDsc, err := conn.Runtime(npa.ParaTime).ROFLMarket.Instance(ctx, client.RoundLatest, *providerAddr, machineID)
+		cobra.CheckErr(err)
+
+		schedulerRAKRaw, ok := insDsc.Metadata[scheduler.MetadataKeySchedulerRAK]
+		if !ok {
+			cobra.CheckErr("Machine is missing scheduler RAK metadata.")
+		}
+		var schedulerRAK ed25519.PublicKey
+		if err := schedulerRAK.UnmarshalText([]byte(schedulerRAKRaw)); err != nil {
+			cobra.CheckErr(fmt.Sprintf("Malformed scheduler RAK metadata: %s", err))
+		}
+		pk := types.PublicKey{PublicKey: schedulerRAK}
+
+		schedulerDsc, err := conn.Runtime(npa.ParaTime).ROFL.AppInstance(ctx, client.RoundLatest, providerDsc.SchedulerApp, pk)
+		cobra.CheckErr(err)
+
+		client, err := scheduler.NewClient(schedulerDsc)
+		cobra.CheckErr(err)
+
+		// TODO: Cache authentication token so we don't need to re-authenticate.
+		acc := common.LoadAccount(cfg, npa.AccountName)
+
+		sigCtx := &signature.RichContext{
+			RuntimeID:    npa.ParaTime.Namespace(),
+			ChainContext: npa.Network.ChainContext,
+			Base:         []byte(scheduler.StdAuthContextBase),
+		}
+		authRequest, err := scheduler.SignLogin(sigCtx, acc.Signer(), client.Host(), *providerAddr)
+		cobra.CheckErr(err)
+
+		err = client.Login(ctx, authRequest)
+		cobra.CheckErr(err)
+
+		logs, err := client.LogsGet(ctx, machineID, time.Time{})
+		cobra.CheckErr(err)
+		for _, line := range logs {
+			fmt.Println(line)
+		}
+	},
+}
+
+func init() {
+	deploymentFlags := flag.NewFlagSet("", flag.ContinueOnError)
+	deploymentFlags.StringVar(&deploymentName, "deployment", buildRofl.DefaultDeploymentName, "deployment name")
+
+	logsCmd.Flags().AddFlagSet(deploymentFlags)
+}

--- a/cmd/rofl/machine/machine.go
+++ b/cmd/rofl/machine/machine.go
@@ -16,4 +16,5 @@ func init() {
 	Cmd.AddCommand(stopCmd)
 	Cmd.AddCommand(removeCmd)
 	Cmd.AddCommand(topUpCmd)
+	Cmd.AddCommand(logsCmd)
 }


### PR DESCRIPTION
Requires at least rofl-scheduler 0.2.0 on the provider side (currently in https://github.com/oasisprotocol/oasis-sdk/pull/2236) with Oasis Core master.