### PR TITLE
cmd/rofl/logs: Add -y for non-interactive mode

### DIFF
--- a/cmd/rofl/machine/logs.go
+++ b/cmd/rofl/machine/logs.go
@@ -96,4 +96,5 @@ func init() {
 	deploymentFlags.StringVar(&deploymentName, "deployment", buildRofl.DefaultDeploymentName, "deployment name")
 
 	logsCmd.Flags().AddFlagSet(deploymentFlags)
+	logsCmd.Flags().AddFlagSet(common.AnswerYesFlag)
 }


### PR DESCRIPTION
You typically don't encrypt test accounts when developing ROFLs, so the `-y` flag comes handy in this case to check the logs.