### PR TITLE
cmd/rofl: Revamp common rofl flags

### DIFF
--- a/cmd/rofl/common/flags.go
+++ b/cmd/rofl/common/flags.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	flag "github.com/spf13/pflag"
+
+	buildRofl "github.com/oasisprotocol/cli/build/rofl"
+)
+
+var (
+	// WipeFlags is the flag for wiping the machine storage on deployment/restart.
+	WipeFlags *flag.FlagSet
+
+	// DeploymentFlags provide the deployment name.
+	DeploymentFlags *flag.FlagSet
+
+	// DeploymentName is the name of the ROFL app deployment.
+	DeploymentName string
+
+	// WipeStorage enables wiping the machine storage on deployment/restart.
+	WipeStorage bool
+)
+
+func init() {
+	WipeFlags = flag.NewFlagSet("", flag.ContinueOnError)
+	WipeFlags.BoolVar(&WipeStorage, "wipe-storage", false, "whether to wipe machine storage")
+
+	DeploymentFlags = flag.NewFlagSet("", flag.ContinueOnError)
+	DeploymentFlags.StringVar(&DeploymentName, "deployment", buildRofl.DefaultDeploymentName, "deployment name")
+}

--- a/cmd/rofl/common/manifest.go
+++ b/cmd/rofl/common/manifest.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/oasisprotocol/cli/build/rofl"
 	"github.com/oasisprotocol/cli/cmd/common"
-	"github.com/oasisprotocol/cli/config"
+	cliConfig "github.com/oasisprotocol/cli/config"
 )
 
 // ManifestOptions configures the manifest options.
@@ -23,20 +23,23 @@ type ManifestOptions struct {
 // selection.
 //
 // In case there is an error in loading the manifest, it aborts the application.
-func LoadManifestAndSetNPA(cfg *config.Config, npa *common.NPASelection, deployment string, opts *ManifestOptions) (*rofl.Manifest, *rofl.Deployment) {
-	manifest, d, err := MaybeLoadManifestAndSetNPA(cfg, npa, deployment, opts)
+func LoadManifestAndSetNPA(opts *ManifestOptions) (*rofl.Manifest, *rofl.Deployment, *common.NPASelection) {
+	cfg := cliConfig.Global()
+	npa := common.GetNPASelection(cfg)
+
+	manifest, d, err := MaybeLoadManifestAndSetNPA(cfg, npa, DeploymentName, opts)
 	cobra.CheckErr(err)
 	if opts != nil && opts.NeedAppID && !d.HasAppID() {
-		cobra.CheckErr(fmt.Errorf("deployment '%s' does not have an app ID set, maybe you need to run `oasis rofl create`", deployment))
+		cobra.CheckErr(fmt.Errorf("deployment '%s' does not have an app ID set, maybe you need to run `oasis rofl create`", DeploymentName))
 	}
-	return manifest, d
+	return manifest, d, npa
 }
 
 // MaybeLoadManifestAndSetNPA loads the ROFL app manifest and reconfigures the
 // network/paratime/account selection.
 //
 // In case there is an error in loading the manifest, it is returned.
-func MaybeLoadManifestAndSetNPA(cfg *config.Config, npa *common.NPASelection, deployment string, opts *ManifestOptions) (*rofl.Manifest, *rofl.Deployment, error) {
+func MaybeLoadManifestAndSetNPA(cfg *cliConfig.Config, npa *common.NPASelection, deployment string, opts *ManifestOptions) (*rofl.Manifest, *rofl.Deployment, error) {
 	manifest, err := rofl.LoadManifest()
 	if err != nil {
 		return nil, nil, err

--- a/cmd/rofl/deploy.go
+++ b/cmd/rofl/deploy.go
@@ -453,7 +453,6 @@ func init() {
 	providerFlags.BoolVar(&deployShowOffers, "show-offers", false, "show all provider offers and quit")
 	providerFlags.BoolVar(&deployReplaceMachine, "replace-machine", false, "rent a new machine if the provided one expired")
 
-	deployCmd.Flags().AddFlagSet(common.SelectorFlags)
 	deployCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
 	deployCmd.Flags().AddFlagSet(providerFlags)
 	deployCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)

--- a/cmd/rofl/deploy.go
+++ b/cmd/rofl/deploy.go
@@ -49,15 +49,13 @@ var (
 		Short: "Deploy ROFL to a specified machine",
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
-			cfg := cliConfig.Global()
-			npa := common.GetNPASelection(cfg)
 			txCfg := common.GetTransactionConfig()
 
 			if txCfg.Offline {
 				cobra.CheckErr("offline mode currently not supported")
 			}
 
-			manifest, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+			manifest, deployment, npa := roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 				NeedAppID: true,
 				NeedAdmin: true,
 			})
@@ -105,7 +103,7 @@ var (
 					if roflServices, ok := provider.DefaultRoflServices[npa.ParaTime.ID]; ok {
 						deployProvider = roflServices.Provider
 					} else {
-						cobra.CheckErr(fmt.Sprintf("Provider not configured for deployment '%s' machine '%s'. Please specify --provider.", deploymentName, deployMachine))
+						cobra.CheckErr(fmt.Sprintf("Provider not configured for deployment '%s' machine '%s'. Please specify --provider.", roflCommon.DeploymentName, deployMachine))
 					}
 				}
 
@@ -113,7 +111,7 @@ var (
 			default:
 				// Already set, require the provider to be omitted or equal.
 				if deployProvider != "" && deployProvider != machine.Provider {
-					cobra.CheckErr(fmt.Sprintf("Provider '%s' conflicts with existing provider '%s' for deployment '%s' machine '%s'. Omit --provider.", deployProvider, machine.Provider, deploymentName, deployMachine))
+					cobra.CheckErr(fmt.Sprintf("Provider '%s' conflicts with existing provider '%s' for deployment '%s' machine '%s'. Omit --provider.", deployProvider, machine.Provider, roflCommon.DeploymentName, deployMachine))
 				}
 			}
 
@@ -132,7 +130,7 @@ var (
 			}
 
 			ociRepository := ociRepository(deployment)
-			orcFilename := roflCommon.GetOrcFilename(manifest, deploymentName)
+			orcFilename := roflCommon.GetOrcFilename(manifest, roflCommon.DeploymentName)
 			fmt.Printf("Pushing ROFL app to OCI repository '%s'...\n", ociRepository)
 			ociDigest, manifestHash := pushBundleToOciRepository(orcFilename, ociRepository)
 			// Save the OCI repository field to the configuration file so we avoid multiple uploads.
@@ -200,7 +198,7 @@ var (
 					TermCount:  deployTermCount,
 				})
 
-				acc := common.LoadAccount(cfg, npa.AccountName)
+				acc := common.LoadAccount(cliConfig.Global(), npa.AccountName)
 				var sigTx, meta any
 				sigTx, meta, err = common.SignParaTimeTransaction(ctx, npa, acc, conn, tx, nil)
 				cobra.CheckErr(err)
@@ -260,12 +258,12 @@ var (
 						Method: scheduler.MethodDeploy,
 						Args: cbor.Marshal(scheduler.DeployRequest{
 							Deployment:  machineDeployment,
-							WipeStorage: false,
+							WipeStorage: roflCommon.WipeStorage,
 						}),
 					})},
 				})
 
-				acc := common.LoadAccount(cfg, npa.AccountName)
+				acc := common.LoadAccount(cliConfig.Global(), npa.AccountName)
 				var sigTx, meta any
 				sigTx, meta, err = common.SignParaTimeTransaction(ctx, npa, acc, conn, tx, nil)
 				cobra.CheckErr(err)
@@ -457,6 +455,7 @@ func init() {
 
 	deployCmd.Flags().AddFlagSet(common.SelectorFlags)
 	deployCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	deployCmd.Flags().AddFlagSet(deploymentFlags)
 	deployCmd.Flags().AddFlagSet(providerFlags)
+	deployCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
+	deployCmd.Flags().AddFlagSet(roflCommon.WipeFlags)
 }

--- a/cmd/rofl/machine/logs.go
+++ b/cmd/rofl/machine/logs.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
 
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
@@ -14,7 +13,6 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/ed25519"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
-	buildRofl "github.com/oasisprotocol/cli/build/rofl"
 	"github.com/oasisprotocol/cli/build/rofl/scheduler"
 	"github.com/oasisprotocol/cli/cmd/common"
 	roflCommon "github.com/oasisprotocol/cli/cmd/rofl/common"
@@ -26,10 +24,7 @@ var logsCmd = &cobra.Command{
 	Short: "Show logs from the given machine",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(_ *cobra.Command, args []string) {
-		cfg := cliConfig.Global()
-		npa := common.GetNPASelection(cfg)
-
-		_, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+		_, deployment, npa := roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 			NeedAppID: true,
 			NeedAdmin: false,
 		})
@@ -70,7 +65,7 @@ var logsCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		// TODO: Cache authentication token so we don't need to re-authenticate.
-		acc := common.LoadAccount(cfg, npa.AccountName)
+		acc := common.LoadAccount(cliConfig.Global(), npa.AccountName)
 
 		sigCtx := &signature.RichContext{
 			RuntimeID:    npa.ParaTime.Namespace(),
@@ -92,9 +87,6 @@ var logsCmd = &cobra.Command{
 }
 
 func init() {
-	deploymentFlags := flag.NewFlagSet("", flag.ContinueOnError)
-	deploymentFlags.StringVar(&deploymentName, "deployment", buildRofl.DefaultDeploymentName, "deployment name")
-
-	logsCmd.Flags().AddFlagSet(deploymentFlags)
+	logsCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	logsCmd.Flags().AddFlagSet(common.AnswerYesFlag)
 }

--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -736,10 +736,6 @@ func init() {
 	updateCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	updateCmd.Flags().AddFlagSet(updateFlags)
 
-	deployCmd.Flags().AddFlagSet(common.SelectorFlags)
-	deployCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	deployCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
-
 	removeCmd.Flags().AddFlagSet(common.SelectorFlags)
 	removeCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
 	removeCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)

--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -40,11 +40,8 @@ var (
 	adminAddress string
 	pubName      string
 
-	appTEE         string
-	appKind        string
-	deploymentName string
-
-	deploymentFlags *flag.FlagSet
+	appTEE  string
+	appKind string
 
 	initCmd = &cobra.Command{
 		Use:   "init [<name>] [--tee TEE] [--kind KIND]",
@@ -177,16 +174,16 @@ var (
 			cobra.CheckErr(err)
 
 			// Load or create a deployment.
-			deployment, ok := manifest.Deployments[deploymentName]
+			deployment, ok := manifest.Deployments[roflCommon.DeploymentName]
 			switch ok {
 			case true:
 				if deployment.AppID != "" {
-					cobra.CheckErr(fmt.Errorf("ROFL app identifier already defined (%s) for deployment '%s', refusing to overwrite", deployment.AppID, deploymentName))
+					cobra.CheckErr(fmt.Errorf("ROFL app identifier already defined (%s) for deployment '%s', refusing to overwrite", deployment.AppID, roflCommon.DeploymentName))
 				}
 
 				// An existing deployment is defined, but without an AppID. Load everything else for
 				// the deployment and proceed with creating a new app.
-				manifest, deployment = roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+				manifest, deployment, npa = roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 					NeedAppID: false,
 					NeedAdmin: true,
 				})
@@ -245,7 +242,7 @@ var (
 				if manifest.Deployments == nil {
 					manifest.Deployments = make(map[string]*buildRofl.Deployment)
 				}
-				manifest.Deployments[deploymentName] = deployment
+				manifest.Deployments[roflCommon.DeploymentName] = deployment
 			}
 
 			idScheme, ok := identifierSchemes[scheme]
@@ -257,7 +254,7 @@ var (
 			tx := rofl.NewCreateTx(nil, &rofl.Create{
 				Policy:   *deployment.Policy.AsDescriptor(),
 				Scheme:   idScheme,
-				Metadata: manifest.GetMetadata(deploymentName),
+				Metadata: manifest.GetMetadata(roflCommon.DeploymentName),
 			})
 
 			acc := common.LoadAccount(cfg, npa.AccountName)
@@ -287,11 +284,9 @@ var (
 		Short: "Update an existing ROFL application",
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
-			cfg := cliConfig.Global()
-			npa := common.GetNPASelection(cfg)
 			txCfg := common.GetTransactionConfig()
 
-			manifest, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+			manifest, deployment, npa := roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 				NeedAppID: true,
 				NeedAdmin: true,
 			})
@@ -330,7 +325,7 @@ var (
 			updateBody := rofl.Update{
 				ID:       appID,
 				Policy:   *deployment.Policy.AsDescriptor(),
-				Metadata: manifest.GetMetadata(deploymentName),
+				Metadata: manifest.GetMetadata(roflCommon.DeploymentName),
 				Secrets:  secrets,
 			}
 
@@ -347,7 +342,7 @@ var (
 			// Prepare transaction.
 			tx := rofl.NewUpdateTx(nil, &updateBody)
 
-			acc := common.LoadAccount(cfg, npa.AccountName)
+			acc := common.LoadAccount(cliConfig.Global(), npa.AccountName)
 			sigTx, meta, err := common.SignParaTimeTransaction(ctx, npa, acc, conn, tx, nil)
 			cobra.CheckErr(err)
 
@@ -372,7 +367,7 @@ var (
 			if len(args) > 0 {
 				rawAppID = args[0]
 			} else {
-				manifest, deployment = roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+				manifest, deployment, npa = roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 					NeedAppID: true,
 					NeedAdmin: true,
 				})
@@ -414,7 +409,7 @@ var (
 
 			// Update manifest to clear the corresponding deployment section.
 			if manifest != nil {
-				delete(manifest.Deployments, deploymentName)
+				delete(manifest.Deployments, roflCommon.DeploymentName)
 				if err = manifest.Save(); err != nil {
 					cobra.CheckErr(fmt.Errorf("failed to update manifest: %w", err))
 				}
@@ -427,14 +422,14 @@ var (
 		Short: "Show information about a ROFL application",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			var rawAppID string
 			cfg := cliConfig.Global()
 			npa := common.GetNPASelection(cfg)
-
-			var rawAppID string
 			if len(args) > 0 {
 				rawAppID = args[0]
 			} else {
-				_, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+				var deployment *buildRofl.Deployment
+				_, deployment, npa = roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 					NeedAppID: true,
 					NeedAdmin: false,
 				})
@@ -554,12 +549,10 @@ var (
 		Short: "Encrypt the given secret into the manifest, reading the value from file or stdin",
 		Args:  cobra.ExactArgs(2),
 		Run: func(_ *cobra.Command, args []string) {
-			cfg := cliConfig.Global()
-			npa := common.GetNPASelection(cfg)
 			secretName := args[0]
 			secretFn := args[1]
 
-			manifest, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+			manifest, deployment, npa := roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 				NeedAppID: true,
 				NeedAdmin: false,
 			})
@@ -605,7 +598,7 @@ var (
 			}
 			for _, sc := range deployment.Secrets {
 				if sc.Name == secretName {
-					cobra.CheckErr(fmt.Errorf("secret named '%s' already exists for deployment '%s'", secretName, deploymentName))
+					cobra.CheckErr(fmt.Errorf("secret named '%s' already exists for deployment '%s'", secretName, roflCommon.DeploymentName))
 				}
 			}
 			deployment.Secrets = append(deployment.Secrets, &secretCfg)
@@ -624,11 +617,9 @@ var (
 		Short: "Show metadata about the given secret",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			cfg := cliConfig.Global()
-			npa := common.GetNPASelection(cfg)
 			secretName := args[0]
 
-			_, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+			_, deployment, _ := roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 				NeedAppID: false,
 				NeedAdmin: false,
 			})
@@ -641,7 +632,7 @@ var (
 				break
 			}
 			if secret == nil {
-				cobra.CheckErr(fmt.Errorf("secret named '%s' does not exist for deployment '%s'", secretName, deploymentName))
+				cobra.CheckErr(fmt.Errorf("secret named '%s' does not exist for deployment '%s'", secretName, roflCommon.DeploymentName))
 				return // Lint doesn't know that cobra.CheckErr never returns.
 			}
 
@@ -658,11 +649,9 @@ var (
 		Short: "Remove the given secret from the manifest",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			cfg := cliConfig.Global()
-			npa := common.GetNPASelection(cfg)
 			secretName := args[0]
 
-			manifest, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+			manifest, deployment, _ := roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 				NeedAppID: false,
 				NeedAdmin: false,
 			})
@@ -679,7 +668,7 @@ var (
 				newSecrets = append(newSecrets, sc)
 			}
 			if !found {
-				cobra.CheckErr(fmt.Errorf("secret named '%s' does not exist for deployment '%s'", secretName, deploymentName))
+				cobra.CheckErr(fmt.Errorf("secret named '%s' does not exist for deployment '%s'", secretName, roflCommon.DeploymentName))
 			}
 			deployment.Secrets = newSecrets
 
@@ -730,44 +719,41 @@ func detectOrCreateComposeFile() string {
 }
 
 func init() {
-	deploymentFlags = flag.NewFlagSet("", flag.ContinueOnError)
-	deploymentFlags.StringVar(&deploymentName, "deployment", buildRofl.DefaultDeploymentName, "deployment name")
-
 	updateFlags := flag.NewFlagSet("", flag.ContinueOnError)
 	updateFlags.StringVar(&adminAddress, "admin", "", "set the administrator address")
-	updateCmd.Flags().AddFlagSet(deploymentFlags)
+	updateCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 
 	initCmd.Flags().StringVar(&appTEE, "tee", "tdx", "TEE kind [tdx, sgx]")
 	initCmd.Flags().StringVar(&appKind, "kind", "container", "ROFL app kind [container, raw]")
 
 	createCmd.Flags().AddFlagSet(common.SelectorFlags)
 	createCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	createCmd.Flags().AddFlagSet(deploymentFlags)
+	createCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	createCmd.Flags().StringVar(&scheme, "scheme", "cn", "app ID generation scheme: creator+round+index [cri] or creator+nonce [cn]")
 
 	updateCmd.Flags().AddFlagSet(common.SelectorFlags)
 	updateCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	updateCmd.Flags().AddFlagSet(deploymentFlags)
+	updateCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	updateCmd.Flags().AddFlagSet(updateFlags)
 
 	deployCmd.Flags().AddFlagSet(common.SelectorFlags)
 	deployCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	deployCmd.Flags().AddFlagSet(deploymentFlags)
+	deployCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 
 	removeCmd.Flags().AddFlagSet(common.SelectorFlags)
 	removeCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
-	removeCmd.Flags().AddFlagSet(deploymentFlags)
+	removeCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 
 	showCmd.Flags().AddFlagSet(common.SelectorFlags)
-	showCmd.Flags().AddFlagSet(deploymentFlags)
+	showCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 
-	secretSetCmd.Flags().AddFlagSet(deploymentFlags)
+	secretSetCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	secretSetCmd.Flags().StringVar(&pubName, "public-name", "", "public secret name")
 	secretCmd.AddCommand(secretSetCmd)
 
-	secretGetCmd.Flags().AddFlagSet(deploymentFlags)
+	secretGetCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	secretCmd.AddCommand(secretGetCmd)
 
-	secretRmCmd.Flags().AddFlagSet(deploymentFlags)
+	secretRmCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	secretCmd.AddCommand(secretRmCmd)
 }

--- a/cmd/rofl/push.go
+++ b/cmd/rofl/push.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/oasisprotocol/cli/cmd/common"
 	roflCommon "github.com/oasisprotocol/cli/cmd/rofl/common"
-	cliConfig "github.com/oasisprotocol/cli/config"
 )
 
 var pushCmd = &cobra.Command{
@@ -15,14 +14,11 @@ var pushCmd = &cobra.Command{
 	Short: "Push ROFL app to OCI repository",
 	Args:  cobra.NoArgs,
 	Run: func(_ *cobra.Command, _ []string) {
-		cfg := cliConfig.Global()
-		npa := common.GetNPASelection(cfg)
-
-		manifest, deployment := roflCommon.LoadManifestAndSetNPA(cfg, npa, deploymentName, &roflCommon.ManifestOptions{
+		manifest, deployment, _ := roflCommon.LoadManifestAndSetNPA(&roflCommon.ManifestOptions{
 			NeedAppID: true,
 		})
 
-		orcFilename := roflCommon.GetOrcFilename(manifest, deploymentName)
+		orcFilename := roflCommon.GetOrcFilename(manifest, roflCommon.DeploymentName)
 		ociRepository := ociRepository(deployment)
 
 		if common.OutputFormat() == common.FormatText {


### PR DESCRIPTION
This PR:
- adds `--wipe-storage` to rofl deploy command which is useful when you set a new storage in the manifest file and redeploy the app.
- moves the following flags into a common file:
  --deployment
  --wipe-storage
- deduplicates npa and cfg initialization unless they can be provided outside of the manifest file (e.g. rofl create)
- fixes #509