### PR TITLE
cmd/rofl: Populate compose.yaml with boilerplate content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: oasis
 
 build-windows: oasis.exe
 
-oasis: $(shell find . -name "*.go" -type f) go.sum go.mod
+oasis: $(shell find . -name "*.go" -type f) $(shell find cmd/rofl/init_artifacts) go.sum go.mod
 	@$(PRINT) "$(MAGENTA)*** Building Go code...$(OFF)\n"
 	@$(GO) build -v -o oasis $(GOFLAGS) $(GO_EXTRA_FLAGS)
 

--- a/cmd/rofl/init_artifacts/compose.yaml
+++ b/cmd/rofl/init_artifacts/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  mycontainer:
+    build: .
+    image: "docker.io/org_name/image_name"      # Always provide FQDN image names!
+    platform: linux/amd64
+    volumes:
+      - my-volume:/root/.my-volume              # Persistent per-machine storage.
+      - /run/rofl-appd.sock:/run/rofl-appd.sock # appd REST API.
+    environment:
+      - MY_SECRET_1=${MY_SECRET_1}              # See `oasis rofl secret` command.
+      - MY_SECRET_2=${MY_SECRET_2}
+
+volumes:
+  my-volume:

--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -42,6 +43,9 @@ var (
 
 	appTEE  string
 	appKind string
+
+	//go:embed init_artifacts/compose.yaml
+	initArtifactCompose []byte
 
 	initCmd = &cobra.Command{
 		Use:   "init [<name>] [--tee TEE] [--kind KIND]",
@@ -709,12 +713,10 @@ func detectOrCreateComposeFile() string {
 	}
 
 	filename := "compose.yaml"
-	f, err := os.OpenFile(filename, os.O_RDONLY|os.O_CREATE, 0o644)
-	if err != nil {
+	if err := os.WriteFile(filename, initArtifactCompose, 0o644); err != nil { //nolint: gosec
 		return ""
 	}
 
-	f.Close()
 	return filename
 }
 


### PR DESCRIPTION
Based on the feedback from one of our partners, it would be a good idea to populate `compose.yaml` with ROFL-specific features (storage, appd, secrets) and then let developer remove those, if not needed.