### PR TITLE
cmd/rofl/build: Fix crash if no artifacts defined

### DIFF
--- a/cmd/rofl/build/build.go
+++ b/cmd/rofl/build/build.go
@@ -89,7 +89,7 @@ var (
 
 			var buildEnv env.ExecEnv
 			switch {
-			case manifest.Artifacts.Builder == "" || noDocker:
+			case manifest.Artifacts == nil || manifest.Artifacts.Builder == "" || noDocker:
 				buildEnv = env.NewNativeEnv()
 			default:
 				var baseDir string


### PR DESCRIPTION
For `sgx-raw` projects, there are no mandatory artifacts defined and since it has the `omitempty` flag, it's not there in the manifest. `oasis rofl build` thus crashes for clean `sgx-raw` projects.