### PR TITLE
fix: sgx-raw builds, -v switch, Cargo.lock generate

### DIFF
--- a/build/cargo/cargo.go
+++ b/build/cargo/cargo.go
@@ -114,10 +114,13 @@ func GetMetadata(env env.ExecEnv) (*Metadata, error) {
 }
 
 // Build builds a Rust program using `cargo` in the current working directory.
-func Build(env env.ExecEnv, release bool, target string, features []string) (string, error) {
-	args := []string{"build", "--locked"}
+func Build(env env.ExecEnv, release, locked bool, target string, features []string) (string, error) {
+	args := []string{"build"}
 	if release {
 		args = append(args, "--release")
+	}
+	if locked {
+		args = append(args, "--locked")
 	}
 	if target != "" {
 		args = append(args, "--target", target)

--- a/build/cargo/cargo.go
+++ b/build/cargo/cargo.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/oasisprotocol/cli/build/env"
+	"github.com/oasisprotocol/cli/cmd/common"
 )
 
 // Metadata is the cargo package metadata.
@@ -52,6 +53,9 @@ func GetMetadata(env env.ExecEnv) (*Metadata, error) {
 	}
 	if err = env.WrapCommand(cmd); err != nil {
 		return nil, err
+	}
+	if common.IsVerbose() {
+		fmt.Println(cmd)
 	}
 	if err = cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start metadata process: %w", err)
@@ -135,6 +139,9 @@ func Build(env env.ExecEnv, release bool, target string, features []string) (str
 
 	if err = env.WrapCommand(cmd); err != nil {
 		return "", err
+	}
+	if common.IsVerbose() {
+		fmt.Println(cmd)
 	}
 	if err = cmd.Start(); err != nil {
 		return "", fmt.Errorf("failed to start build process: %w", err)

--- a/build/env/env.go
+++ b/build/env/env.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/oasisprotocol/cli/cmd/common"
 )
 
 // ExecEnv is an execution environment.
@@ -191,6 +193,9 @@ func (de *DockerEnv) FixPermissions(path string) error {
 	cmd := exec.Command("chown", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()), path) //nolint: gosec
 	if err = de.WrapCommand(cmd); err != nil {
 		return err
+	}
+	if common.IsVerbose() {
+		fmt.Println(cmd)
 	}
 	return cmd.Run()
 }

--- a/build/sgxs/sgxs.go
+++ b/build/sgxs/sgxs.go
@@ -2,10 +2,12 @@
 package sgxs
 
 import (
+	"fmt"
 	"os/exec"
 	"strconv"
 
 	"github.com/oasisprotocol/cli/build/env"
+	"github.com/oasisprotocol/cli/cmd/common"
 )
 
 // Elf2Sgxs converts an ELF binary built for the SGX ABI into an SGXS binary.
@@ -23,6 +25,9 @@ func Elf2Sgxs(buildEnv env.ExecEnv, elfSgxPath, sgxsPath string, heapSize, stack
 	cmd := exec.Command("ftxsgx-elf2sgxs", args...)
 	if err := buildEnv.WrapCommand(cmd); err != nil {
 		return err
+	}
+	if common.IsVerbose() {
+		fmt.Println(cmd)
 	}
 	return cmd.Run()
 }

--- a/build/sgxs/sgxs.go
+++ b/build/sgxs/sgxs.go
@@ -13,7 +13,14 @@ import (
 // Elf2Sgxs converts an ELF binary built for the SGX ABI into an SGXS binary.
 //
 // It requires the `ftxsgx-elf2sgxs` utility to be installed.
-func Elf2Sgxs(buildEnv env.ExecEnv, elfSgxPath, sgxsPath string, heapSize, stackSize, threads uint64) error {
+func Elf2Sgxs(buildEnv env.ExecEnv, elfSgxPath, sgxsPath string, heapSize, stackSize, threads uint64) (err error) {
+	if elfSgxPath, err = buildEnv.PathToEnv(elfSgxPath); err != nil {
+		return
+	}
+	if sgxsPath, err = buildEnv.PathToEnv(sgxsPath); err != nil {
+		return
+	}
+
 	args := []string{
 		elfSgxPath,
 		"--heap-size", strconv.FormatUint(heapSize, 10),
@@ -23,8 +30,8 @@ func Elf2Sgxs(buildEnv env.ExecEnv, elfSgxPath, sgxsPath string, heapSize, stack
 	}
 
 	cmd := exec.Command("ftxsgx-elf2sgxs", args...)
-	if err := buildEnv.WrapCommand(cmd); err != nil {
-		return err
+	if err = buildEnv.WrapCommand(cmd); err != nil {
+		return
 	}
 	if common.IsVerbose() {
 		fmt.Println(cmd)

--- a/cmd/common/flags.go
+++ b/cmd/common/flags.go
@@ -22,6 +22,9 @@ var (
 
 	// FormatFlag specifies the command's output format (text/json).
 	FormatFlag *flag.FlagSet
+
+	// VerboseFlag specifies the command's verbosity.
+	VerboseFlag *flag.FlagSet
 )
 
 // FormatType specifies the type of format for output of commands.
@@ -61,6 +64,7 @@ var (
 	force          bool
 	answerYes      bool
 	outputFormat   = FormatText
+	verbose        bool
 )
 
 // GetHeight returns the user-selected block height.
@@ -82,6 +86,11 @@ func GetAnswerYes() bool {
 // OutputFormat returns the format of the command's output.
 func OutputFormat() FormatType {
 	return outputFormat
+}
+
+// IsVerbose returns verbose mode.
+func IsVerbose() bool {
+	return verbose
 }
 
 // GetActualHeight returns the user-selected block height if explicitly
@@ -113,4 +122,7 @@ func init() {
 
 	FormatFlag = flag.NewFlagSet("", flag.ContinueOnError)
 	FormatFlag.Var(&outputFormat, "format", "output format ["+strings.Join([]string{string(FormatText), string(FormatJSON)}, ",")+"]")
+
+	VerboseFlag = flag.NewFlagSet("", flag.ContinueOnError)
+	VerboseFlag.BoolVarP(&verbose, "verbose", "v", false, "verbose")
 }

--- a/cmd/rofl/build/build.go
+++ b/cmd/rofl/build/build.go
@@ -134,12 +134,12 @@ var (
 					return fmt.Errorf("unsupported app kind for SGX TEE: %s", manifest.Kind)
 				}
 
-				sgxBuild(buildEnv, npa, manifest, deployment, bnd)
+				sgxBuild(buildEnv, npa, manifest, deployment, bnd, doVerify)
 			case buildRofl.TEETypeTDX:
 				// TDX.
 				switch manifest.Kind {
 				case buildRofl.AppKindRaw:
-					err = tdxBuildRaw(buildEnv, tmpDir, npa, manifest, deployment, bnd)
+					err = tdxBuildRaw(buildEnv, tmpDir, npa, manifest, deployment, bnd, doVerify)
 				case buildRofl.AppKindContainer:
 					err = tdxBuildContainer(buildEnv, tmpDir, npa, manifest, deployment, bnd)
 				}

--- a/cmd/rofl/build/build.go
+++ b/cmd/rofl/build/build.go
@@ -290,6 +290,11 @@ func setupBuildEnv(deployment *buildRofl.Deployment, npa *common.NPASelection) {
 
 	// Obtain and configure trust root.
 	trustRoot, err := fetchTrustRoot(npa, deployment.TrustRoot)
+	if deployment.Debug && err != nil {
+		// Trust root is not mandatory for debug builds.
+		fmt.Printf("WARNING: no trust root will be provided during compilation: %v\n", err)
+		return
+	}
 	cobra.CheckErr(err)
 	os.Setenv("ROFL_CONSENSUS_TRUST_ROOT", trustRoot)
 }

--- a/cmd/rofl/build/build.go
+++ b/cmd/rofl/build/build.go
@@ -366,6 +366,8 @@ func init() {
 	buildFlags.BoolVar(&onlyValidate, "only-validate", false, "validate without building")
 
 	buildFlags.AddFlagSet(roflCommon.DeploymentFlags)
+	buildFlags.AddFlagSet(common.VerboseFlag)
+	buildFlags.AddFlagSet(common.ForceFlag)
 
 	// TODO: Remove when all the examples, demos and docs are updated.
 	var dummy bool
@@ -373,5 +375,4 @@ func init() {
 	_ = buildFlags.MarkDeprecated("update-manifest", "the app manifest is now updated by default. Pass --no-update-manifest to prevent updating it.")
 
 	Cmd.Flags().AddFlagSet(buildFlags)
-	Cmd.Flags().AddFlagSet(common.ForceFlag)
 }

--- a/cmd/rofl/build/build.go
+++ b/cmd/rofl/build/build.go
@@ -33,7 +33,6 @@ var (
 	outputFn     string
 	buildMode    string
 	offline      bool
-	noUpdate     bool
 	doVerify     bool
 	noDocker     bool
 	onlyValidate bool
@@ -242,10 +241,10 @@ var (
 
 			// Override the update manifest flag in case the policy does not exist.
 			if deployment.Policy == nil {
-				noUpdate = true
+				roflCommon.NoUpdate = true
 			}
 
-			switch noUpdate {
+			switch roflCommon.NoUpdate {
 			case true:
 				// Ask the user to update the manifest manually (if the manifest has changed).
 				if maps.Equal(buildEnclaves, latestManifestEnclaves) {
@@ -360,19 +359,14 @@ func init() {
 	buildFlags := flag.NewFlagSet("", flag.ContinueOnError)
 	buildFlags.BoolVar(&offline, "offline", false, "do not perform any operations requiring network access")
 	buildFlags.StringVar(&outputFn, "output", "", "output bundle filename")
-	buildFlags.BoolVar(&noUpdate, "no-update-manifest", false, "do not update the manifest")
 	buildFlags.BoolVar(&doVerify, "verify", false, "verify build against manifest and on-chain state")
 	buildFlags.BoolVar(&noDocker, "no-docker", false, "do not use the Dockerized builder")
 	buildFlags.BoolVar(&onlyValidate, "only-validate", false, "validate without building")
 
 	buildFlags.AddFlagSet(roflCommon.DeploymentFlags)
+	buildFlags.AddFlagSet(roflCommon.NoUpdateFlag)
 	buildFlags.AddFlagSet(common.VerboseFlag)
 	buildFlags.AddFlagSet(common.ForceFlag)
-
-	// TODO: Remove when all the examples, demos and docs are updated.
-	var dummy bool
-	buildFlags.BoolVar(&dummy, "update-manifest", true, "not update the manifest")
-	_ = buildFlags.MarkDeprecated("update-manifest", "the app manifest is now updated by default. Pass --no-update-manifest to prevent updating it.")
 
 	Cmd.Flags().AddFlagSet(buildFlags)
 }

--- a/cmd/rofl/build/sgx.go
+++ b/cmd/rofl/build/sgx.go
@@ -32,6 +32,7 @@ func sgxBuild(
 	manifest *buildRofl.Manifest,
 	deployment *buildRofl.Deployment,
 	bnd *bundle.Bundle,
+	locked bool,
 ) {
 	fmt.Println("Building an SGX-based Rust ROFL application...")
 
@@ -39,14 +40,14 @@ func sgxBuild(
 
 	// First build for the default target.
 	fmt.Println("Building ELF binary...")
-	elfPath, err := cargo.Build(buildEnv, true, "x86_64-unknown-linux-gnu", features)
+	elfPath, err := cargo.Build(buildEnv, true, locked, "x86_64-unknown-linux-gnu", features)
 	if err != nil {
 		cobra.CheckErr(fmt.Errorf("failed to build ELF binary: %w", err))
 	}
 
 	// Then build for the SGX target.
 	fmt.Println("Building SGXS binary...")
-	elfSgxPath, err := cargo.Build(buildEnv, true, "x86_64-fortanix-unknown-sgx", nil)
+	elfSgxPath, err := cargo.Build(buildEnv, true, locked, "x86_64-fortanix-unknown-sgx", nil)
 	if err != nil {
 		cobra.CheckErr(fmt.Errorf("failed to build SGXS binary: %w", err))
 	}

--- a/cmd/rofl/build/sgx.go
+++ b/cmd/rofl/build/sgx.go
@@ -109,9 +109,11 @@ func sgxBuild(
 	sigName := "app.sig"
 
 	comp := bundle.Component{
-		Kind:       component.ROFL,
-		Name:       bnd.Manifest.Name,
-		Executable: execName,
+		Kind: component.ROFL,
+		Name: bnd.Manifest.Name,
+		ELF: &bundle.ELFMetadata{
+			Executable: execName,
+		},
 		SGX: &bundle.SGXMetadata{
 			Executable: sgxsName,
 			Signature:  sigName,

--- a/cmd/rofl/build/tdx.go
+++ b/cmd/rofl/build/tdx.go
@@ -36,6 +36,7 @@ func tdxBuildRaw(
 	manifest *buildRofl.Manifest,
 	deployment *buildRofl.Deployment,
 	bnd *bundle.Bundle,
+	locked bool,
 ) error {
 	wantedArtifacts := tdxWantedArtifacts(manifest, buildRofl.LatestBasicArtifacts)
 	artifacts := tdxFetchArtifacts(wantedArtifacts)
@@ -62,7 +63,7 @@ func tdxBuildRaw(
 	}
 
 	fmt.Println("Building runtime binary...")
-	initPath, err := cargo.Build(buildEnv, true, "", nil)
+	initPath, err := cargo.Build(buildEnv, true, locked, "", nil)
 	if err != nil {
 		return fmt.Errorf("failed to build runtime binary: %w", err)
 	}

--- a/cmd/rofl/common/flags.go
+++ b/cmd/rofl/common/flags.go
@@ -13,11 +13,17 @@ var (
 	// DeploymentFlags provide the deployment name.
 	DeploymentFlags *flag.FlagSet
 
+	// NoUpdateFlag is the flag for disabling the rofl.yaml manifest file update.
+	NoUpdateFlag *flag.FlagSet
+
 	// DeploymentName is the name of the ROFL app deployment.
 	DeploymentName string
 
 	// WipeStorage enables wiping the machine storage on deployment/restart.
 	WipeStorage bool
+
+	// NoUpdate disables updating the rofl.yaml manifest file.
+	NoUpdate bool
 )
 
 func init() {
@@ -26,4 +32,7 @@ func init() {
 
 	DeploymentFlags = flag.NewFlagSet("", flag.ContinueOnError)
 	DeploymentFlags.StringVar(&DeploymentName, "deployment", buildRofl.DefaultDeploymentName, "deployment name")
+
+	NoUpdateFlag = flag.NewFlagSet("", flag.ContinueOnError)
+	NoUpdateFlag.BoolVar(&NoUpdate, "no-update-manifest", false, "do not update the manifest")
 }

--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -279,8 +279,10 @@ var (
 			// Update the manifest with the given enclave identities, overwriting existing ones.
 			deployment.AppID = appID.String()
 
-			if err = manifest.Save(); err != nil {
-				cobra.CheckErr(fmt.Errorf("failed to update manifest: %w", err))
+			if !roflCommon.NoUpdate {
+				if err = manifest.Save(); err != nil {
+					cobra.CheckErr(fmt.Errorf("failed to update manifest: %w", err))
+				}
 			}
 
 			fmt.Printf("Run `oasis rofl build` to build your ROFL app.\n")
@@ -735,6 +737,7 @@ func init() {
 	createCmd.Flags().AddFlagSet(common.SelectorFlags)
 	createCmd.Flags().AddFlagSet(common.RuntimeTxFlags)
 	createCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
+	createCmd.Flags().AddFlagSet(roflCommon.NoUpdateFlag)
 	createCmd.Flags().StringVar(&scheme, "scheme", "cn", "app ID generation scheme: creator+round+index [cri] or creator+nonce [cn]")
 
 	updateCmd.Flags().AddFlagSet(common.SelectorFlags)


### PR DESCRIPTION
CLI bugfixes discovered during https://github.com/oasisprotocol/oasis-sdk/issues/2090:
- sgx-raw builds can now be built with the rofl-dev builder
- a new verbose switch `-v` was introduced which prints out exact build commands
- `Cargo.lock` is now overwritten/regenerated by default and the `--locked` switch is passed only in the `oasis rofl build --verify` mode
- trust root is optional for debug builds
- `oasis rofl create` now also supports `--no-update-manifest` switch if you simply want to register a new rofl app