### PR TITLE
feat: add oasis update command to cli

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -19,7 +19,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     # NOTE: This name appears in GitHub's Checks API.
     name: tests-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -44,6 +44,7 @@ jobs:
         run: |
           make test
       - name: Check examples
+        if: runner.os != 'Windows'
         run: |
           make clean-examples
           make examples

--- a/cmd/common/progress.go
+++ b/cmd/common/progress.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// ProgressOption configures the behaviour of ProgressWriter.
+type ProgressOption func(*ProgressWriter)
+
+// WithMessage sets the status prefix shown before percentage/KiB.
+func WithMessage(msg string) ProgressOption {
+	return func(p *ProgressWriter) { p.msg = msg }
+}
+
+// WithFrequency sets how often updates are printed.
+func WithFrequency(freq time.Duration) ProgressOption {
+	return func(p *ProgressWriter) { p.freq = freq }
+}
+
+// WithOutput sets the destination writer (defaults to os.Stderr).
+func WithOutput(w io.Writer) ProgressOption {
+	return func(p *ProgressWriter) { p.out = w }
+}
+
+// ProgressWriter is an io.Writer that prints a simple progress bar.
+// It is safe to use with io.TeeReader.
+//
+//	pw := common.NewProgressWriter(resp.ContentLength, common.WithMessage("Downloading..."))
+//	io.Copy(dst, io.TeeReader(src, pw))
+type ProgressWriter struct {
+	written    int64
+	lastPrint  time.Time
+	contentLen int64
+
+	msg  string
+	freq time.Duration
+	out  io.Writer
+}
+
+const defaultFreq = 500 * time.Millisecond
+
+// NewProgressWriter returns a configured ProgressWriter.
+func NewProgressWriter(contentLen int64, opts ...ProgressOption) *ProgressWriter {
+	pw := &ProgressWriter{
+		contentLen: contentLen,
+		msg:        "Progress...",
+		freq:       defaultFreq,
+		out:        os.Stderr,
+	}
+	for _, o := range opts {
+		o(pw)
+	}
+	return pw
+}
+
+// Write implements io.Writer.
+func (p *ProgressWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	p.written += int64(n)
+	now := time.Now()
+
+	if now.Sub(p.lastPrint) >= p.freq || p.written == p.contentLen {
+		if p.contentLen > 0 {
+			percent := float64(p.written) / float64(p.contentLen) * 100
+			fmt.Fprintf(p.out, "\r%s %5.1f%%", p.msg, percent)
+			if p.written == p.contentLen {
+				fmt.Fprintln(p.out)
+			}
+		} else {
+			fmt.Fprintf(p.out, "\r%s %d KiB", p.msg, p.written/1024)
+		}
+		p.lastPrint = now
+	}
+	return n, nil
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,510 @@
+package cmd
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	progress "github.com/oasisprotocol/cli/cmd/common"
+
+	cliVersion "github.com/oasisprotocol/cli/version"
+	"github.com/spf13/cobra"
+)
+
+const (
+	apiTimeout           = 15 * time.Second
+	downloadTimeout      = 5 * time.Minute
+	maxChecksumSize      = 16 * 1024
+	retryAfterMaxSeconds = 60 // upper bound for GitHub's Retry-After header
+)
+
+const (
+	osWindows     = "windows"
+	binaryName    = "oasis"
+	binaryNameWin = binaryName + ".exe"
+)
+
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	},
+}
+
+var (
+	githubAPIBase = "https://api.github.com"
+	download      = doDownload
+	osExecutable  = os.Executable
+)
+
+// semverDiffers reports whether versions a and b differ (ignoring leading 'v').
+func semverDiffers(a, b string) (bool, error) {
+	normalize := func(s string) string {
+		s = strings.TrimPrefix(s, "v")
+		// Strip pre-release (-) and build metadata (+)
+		if idx := strings.IndexAny(s, "+-"); idx != -1 {
+			s = s[:idx]
+		}
+		return s
+	}
+
+	aNorm := normalize(a)
+	bNorm := normalize(b)
+
+	if aNorm == "" || bNorm == "" {
+		return false, fmt.Errorf("invalid version string (empty)")
+	}
+	return aNorm != bNorm, nil
+}
+
+// ghRelease mirrors the subset of fields returned by GitHub’s
+// “Get the latest release” endpoint.
+// https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release
+type ghRelease struct {
+	TagName string `json:"tag_name"`
+	Body    string `json:"body"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+func fetchLatest(ctx context.Context) (*ghRelease, error) {
+	url := githubAPIBase + "/repos/oasisprotocol/cli/releases/latest"
+
+	for {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		req.Header.Set("User-Agent", "oasis-cli-updater")
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if t := os.Getenv("GITHUB_TOKEN"); t != "" {
+			req.Header.Set("Authorization", "Bearer "+t)
+		}
+
+		res, err := httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if res.StatusCode == http.StatusForbidden {
+			if sec, _ := strconv.Atoi(res.Header.Get("Retry-After")); sec > 0 && sec < retryAfterMaxSeconds {
+				res.Body.Close()
+				time.Sleep(time.Duration(sec) * time.Second)
+				continue
+			}
+		}
+
+		if res.StatusCode != http.StatusOK {
+			err = fmt.Errorf("GitHub API: %s", res.Status)
+			res.Body.Close()
+			return nil, err
+		}
+
+		var rel ghRelease
+		decodeErr := json.NewDecoder(res.Body).Decode(&rel)
+		res.Body.Close()
+		return &rel, decodeErr
+	}
+}
+
+var archRE = map[string]*regexp.Regexp{
+	"amd64": regexp.MustCompile(`(?:^|[-_])(amd64|x86_64|x64)(?:[-_.]|$)`),
+	"arm64": regexp.MustCompile(`(?:^|[-_])(arm64|aarch64|universal)(?:[-_.]|$)`),
+}
+
+// archAliases returns candidate substrings ordered by preference.
+func archAliases(arch string) []string {
+	switch arch {
+	case "amd64":
+		return []string{"amd64", "x86_64", "x64", "universal", "all"}
+	case "arm64":
+		return []string{"arm64", "aarch64", "universal", "all"}
+	default:
+		return []string{arch, "all"}
+	}
+}
+
+func matches(goos, goarch, asset string) bool {
+	if !strings.Contains(asset, goos) {
+		return false
+	}
+	if re, ok := archRE[goarch]; ok {
+		return re.MatchString(asset)
+	}
+	return strings.Contains(asset, goarch)
+}
+
+func findAssetFor(rel *ghRelease, goos, goarch string) (name, url string, err error) {
+	for _, wantArch := range archAliases(goarch) {
+		for _, a := range rel.Assets {
+			if matches(goos, wantArch, strings.ToLower(a.Name)) {
+				return a.Name, a.BrowserDownloadURL, nil
+			}
+		}
+	}
+	names := make([]string, 0, len(rel.Assets))
+	for _, a := range rel.Assets {
+		names = append(names, a.Name)
+	}
+	return "", "", fmt.Errorf("no asset for %s/%s (available: %v)", goos, goarch, names)
+}
+
+func findAsset(rel *ghRelease) (name, url string, err error) {
+	return findAssetFor(rel, runtime.GOOS, runtime.GOARCH)
+}
+
+func findSha256For(rel *ghRelease) (url string, ok bool) {
+	for _, a := range rel.Assets {
+		lower := strings.ToLower(a.Name)
+		if strings.Contains(lower, "sha256") || strings.Contains(lower, "checksums") {
+			return a.BrowserDownloadURL, true
+		}
+	}
+	return "", false
+}
+
+// doDownload fetches the URL to a temporary file and reports its path.
+func doDownload(ctx context.Context, url string) (string, error) {
+	if !strings.HasPrefix(url, "https://") {
+		return "", errors.New("refusing to download from non-HTTPS URL")
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed: %s", res.Status)
+	}
+
+	tmp, err := os.CreateTemp("", "oasis-update-*")
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+
+	pw := progress.NewProgressWriter(res.ContentLength, progress.WithMessage("Downloading..."))
+	_, err = io.Copy(tmp, io.TeeReader(res.Body, pw))
+	if err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func replaceExecutable(dest string, r io.Reader, perm os.FileMode) error {
+	dir := filepath.Dir(dest)
+
+	tmp, err := os.CreateTemp(dir, ".oasis-new-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = io.Copy(tmp, r); err != nil {
+		return err
+	}
+
+	if perm == 0 {
+		perm = 0o755
+	}
+	if err = tmp.Chmod(perm); err != nil && runtime.GOOS != osWindows {
+		return err
+	}
+
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+
+	if err = os.Rename(tmpPath, dest); err == nil {
+		cleanup = false
+		return nil
+	}
+
+	if runtime.GOOS == osWindows {
+		pending := dest + ".new"
+		if err2 := os.Rename(tmpPath, pending); err2 != nil {
+			return fmt.Errorf("rename failed (%v / %v)", err, err2)
+		}
+		scheduleWindowsMove(pending, dest)
+		cleanup = false
+		fmt.Println("Update staged. It will be applied automatically on next launch.")
+		return nil
+	}
+
+	return err
+}
+
+func scheduleWindowsMove(src, dst string) {
+	if runtime.GOOS != osWindows {
+		return
+	}
+
+	curPID := os.Getpid()
+
+	// Prefer modern PowerShell Core if available.
+	shell := "powershell"
+	if pwsh, err := exec.LookPath("pwsh"); err == nil {
+		shell = pwsh
+	}
+
+	psScript := fmt.Sprintf(
+		`Wait-Process -Id %d -Timeout 15; Move-Item -LiteralPath %q -Destination %q -Force`,
+		curPID, src, dst,
+	)
+	psCmd := exec.Command(shell,
+		"-NoLogo", "-NoProfile", "-Command", psScript,
+	)
+	if err := psCmd.Start(); err == nil {
+		return
+	}
+
+	// Fallback to classic cmd.exe with timeout; /nobreak prevents key-press abort.
+	_ = exec.Command("cmd", "/C",
+		"timeout", "/t", "2", "/nobreak", ">", "nul", "&&",
+		"move", "/Y", src, dst,
+	).Start()
+}
+
+func finishPendingWindowsUpdate(exePath string) {
+	if runtime.GOOS != osWindows {
+		return
+	}
+	pending := exePath + ".new"
+	if _, err := os.Stat(pending); err == nil {
+		_ = os.Rename(pending, exePath)
+	}
+}
+
+func extractBinary(binPath, assetPath, assetName string) error {
+	lower := strings.ToLower(assetName)
+
+	switch {
+	case strings.HasSuffix(lower, ".zip"):
+		zr, err := zip.OpenReader(assetPath)
+		if err != nil {
+			return err
+		}
+		defer zr.Close()
+
+		for _, f := range zr.File {
+			base := filepath.Base(f.Name)
+			if base == binaryName || base == binaryNameWin {
+				rc, err := f.Open()
+				if err != nil {
+					return err
+				}
+				defer rc.Close()
+				return replaceExecutable(binPath, rc, f.Mode())
+			}
+		}
+		return errors.New("binary not found in zip")
+
+	case strings.HasSuffix(lower, ".tar.gz"), strings.HasSuffix(lower, ".tgz"):
+		f, err := os.Open(assetPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		gzr, err := gzip.NewReader(f)
+		if err != nil {
+			return err
+		}
+		defer gzr.Close()
+
+		tr := tar.NewReader(gzr)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			base := filepath.Base(hdr.Name)
+			if hdr.Typeflag == tar.TypeReg && (base == binaryName || base == binaryNameWin) {
+				return replaceExecutable(binPath, tr, hdr.FileInfo().Mode())
+			}
+		}
+		return errors.New("binary not found in tar.gz")
+
+	default:
+		f, err := os.Open(assetPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return replaceExecutable(binPath, f, 0)
+	}
+}
+
+func verifySHA256(filePath, shaPath, assetName string) error {
+	info, err := os.Stat(shaPath)
+	if err != nil {
+		return err
+	}
+	if info.Size() > maxChecksumSize {
+		return fmt.Errorf("checksum file too large: %d bytes", info.Size())
+	}
+
+	f, err := os.Open(shaPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var hashHex string
+	scanner := bufio.NewScanner(f)
+	base := filepath.Base(assetName)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue // ignore blanks & comments
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 1 {
+			// Single-line checksum file.
+			hashHex = fields[0]
+			break
+		}
+		if len(fields) >= 2 && fields[1] == base {
+			hashHex = fields[0]
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if hashHex == "" {
+		return fmt.Errorf("checksum for %q not found in %q", base, shaPath)
+	}
+
+	want, err := hex.DecodeString(hashHex)
+	if err != nil || len(want) != sha256.Size {
+		return errors.New("invalid sha256 checksum")
+	}
+
+	bin, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer bin.Close()
+
+	h := sha256.New()
+	if _, err = io.Copy(h, bin); err != nil {
+		return err
+	}
+	got := h.Sum(nil)
+
+	if !bytes.Equal(got, want) {
+		return fmt.Errorf("checksum mismatch: expected %s got %s",
+			hashHex, hex.EncodeToString(got))
+	}
+	return nil
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Download and install the newest Oasis CLI release",
+	Long: `Checks GitHub releases for a newer Oasis CLI version that matches
+your platform, prints the changelog, optionally asks for confirmation,
+then downloads and replaces the current binary.`,
+	Args: cobra.NoArgs,
+	Run: func(_ *cobra.Command, _ []string) {
+		exePath, err := osExecutable()
+		cobra.CheckErr(err)
+		finishPendingWindowsUpdate(exePath)
+
+		apiCtx, cancel := context.WithTimeout(context.Background(), apiTimeout)
+		defer cancel()
+
+		fmt.Println("Checking for updates...")
+		rel, err := fetchLatest(apiCtx)
+		cobra.CheckErr(err)
+
+		current := cliVersion.Software
+		latest := rel.TagName
+
+		isNewer, err := semverDiffers(latest, current)
+		cobra.CheckErr(err)
+		if !isNewer {
+			fmt.Printf("Oasis CLI is already up to date (%s).\n", current)
+			return
+		}
+
+		assetName, assetURL, err := findAsset(rel)
+		cobra.CheckErr(err)
+
+		fmt.Printf("New version %s available (%s).\n", latest, assetName)
+
+		fmt.Printf("\n─ Changelog for %s ─\n%s\n", latest, rel.Body)
+
+		// Ask for confirmation unless -y/--yes used.
+		progress.Confirm("Upgrade now?", "upgrade cancelled")
+
+		dlCtx, cancelDL := context.WithTimeout(context.Background(), downloadTimeout)
+		defer cancelDL()
+
+		assetPath, err := download(dlCtx, assetURL)
+		cobra.CheckErr(err)
+		defer func() { _ = os.Remove(assetPath) }()
+
+		shaURL, ok := findSha256For(rel) // updated call
+		if !ok {
+			cobra.CheckErr(fmt.Errorf("sha256 checksum not found"))
+		}
+
+		fmt.Println("Verifying integrity...")
+		shaPath, err2 := download(dlCtx, shaURL)
+		cobra.CheckErr(err2)
+		defer func() { _ = os.Remove(shaPath) }()
+		cobra.CheckErr(verifySHA256(assetPath, shaPath, assetName))
+		fmt.Println("Checksum verified OK")
+
+		fmt.Println("Installing...")
+		cobra.CheckErr(extractBinary(exePath, assetPath, assetName))
+
+		fmt.Printf("Updated to %s\n", latest)
+	},
+}
+
+func init() {
+	updateCmd.Flags().AddFlagSet(progress.AnswerYesFlag)
+	rootCmd.AddCommand(updateCmd)
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	cliVersion "github.com/oasisprotocol/cli/version"
+)
+
+func makeReleaseJSON(tag, body, assetName, assetURL string) string {
+	return fmt.Sprintf(`{
+	"tag_name": %q,
+	"body": %q,
+	"assets": [
+		{"name": %q, "browser_download_url": %q},
+		{"name": %q, "browser_download_url": %q}
+	]
+}`, tag, body, assetName, assetURL, assetName+".sha256", assetURL+".sha256")
+}
+
+func tarGz(t *testing.T, path, exeName string, content []byte) {
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create tarGz: %v", err)
+	}
+	gzw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gzw)
+
+	hdr := &tar.Header{Name: exeName, Mode: 0o755, Size: int64(len(content))}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("hdr: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw close: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzw close: %v", err)
+	}
+	_ = f.Close()
+}
+
+func TestUpdate_PositiveFlow(t *testing.T) {
+	tmp := t.TempDir()
+	exeName := "oasis"
+	if runtime.GOOS == osWindows {
+		exeName += ".exe"
+	}
+	binPath := filepath.Join(tmp, exeName)
+
+	if err := os.WriteFile(binPath, []byte("old"), 0o600); err != nil {
+		t.Fatalf("prep bin: %v", err)
+	}
+
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/oasisprotocol/cli/releases/latest":
+			fmt.Fprint(w, makeReleaseJSON("v99.0.0", "body", "oasis-"+runtime.GOOS+"-"+runtime.GOARCH+".tar.gz", ts.URL+"/asset"))
+		case "/asset":
+			asset := filepath.Join(tmp, "asset.tgz")
+			tarGz(t, asset, exeName, []byte("new"))
+			http.ServeFile(w, r, asset)
+		case "/asset.sha256":
+			asset := filepath.Join(tmp, "asset.tgz")
+			f, err := os.Open(asset)
+			if err != nil {
+				t.Fatalf("open asset for sha: %v", err)
+			}
+			defer f.Close()
+
+			h := sha256.New()
+			if _, err := io.Copy(h, f); err != nil {
+				t.Fatalf("hash asset: %v", err)
+			}
+			sum := hex.EncodeToString(h.Sum(nil))
+			// Single-field format is accepted by verifySHA256.
+			fmt.Fprintln(w, sum)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	oldAPI := githubAPIBase
+	oldDL := download
+	githubAPIBase = ts.URL
+	// Custom downloader that works over plain HTTP for the test server.
+	download = func(ctx context.Context, url string) (string, error) {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("download failed: %s", res.Status)
+		}
+
+		tmp, err := os.CreateTemp("", "oasis-update-test-*")
+		if err != nil {
+			return "", err
+		}
+		defer tmp.Close()
+
+		if _, err = io.Copy(tmp, res.Body); err != nil {
+			return "", err
+		}
+		return tmp.Name(), nil
+	}
+	defer func() {
+		githubAPIBase = oldAPI
+		download = oldDL
+	}()
+
+	exit := runTestUpdate(binPath)
+	if exit != 0 {
+		t.Fatalf("unexpected exit code %d", exit)
+	}
+
+	got, _ := os.ReadFile(binPath)
+
+	// Non-Windows platforms: the binary must be replaced in place.
+	if runtime.GOOS != osWindows {
+		if string(got) != "new" {
+			t.Fatalf("binary not replaced, got %q", got)
+		}
+		return
+	}
+
+	// Windows: updater may stage a replacement binary when in-place rename fails.
+	if _, err := os.Stat(binPath + ".new"); err == nil {
+		// Staged file exists; success.
+		return
+	}
+
+	// No staged file; ensure the binary was replaced in place.
+	if string(got) != "new" {
+		t.Fatalf("binary not replaced or staged on windows; got %q", got)
+	}
+}
+
+func TestUpdate_AlreadyUpToDate(t *testing.T) {
+	tmp := t.TempDir()
+	exe := filepath.Join(tmp, "oasis")
+	os.WriteFile(exe, []byte("current"), 0o600) //nolint:errcheck
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, makeReleaseJSON("v0.0.0", "-", "-", "-"))
+	}))
+	defer ts.Close()
+
+	oldAPI := githubAPIBase
+	githubAPIBase = ts.URL
+	defer func() { githubAPIBase = oldAPI }()
+
+	// Override current CLI version to match latest so updater thinks we're up to date.
+	oldVer := cliVersion.Software
+	cliVersion.Software = "0.0.0"
+	defer func() { cliVersion.Software = oldVer }()
+
+	if code := runTestUpdate(exe); code != 0 {
+		t.Fatalf("expected 0 exit, got %d", code)
+	}
+}
+
+// runTestUpdate is a local runner that avoids cobra / os.Exit in tests.
+func runTestUpdate(oasisBinaryPath string) int {
+	// monkey patch os.Executable
+	oldFn := osExecutable
+	osExecutable = func() (string, error) { return oasisBinaryPath, nil }
+	defer func() { osExecutable = oldFn }()
+
+	// Ensure a clean slate for cobra flags between tests.
+	rootCmd.ResetFlags()
+	rootCmd.SetArgs([]string{"update", "--yes"})
+	err := rootCmd.Execute()
+	if err != nil {
+		return 1
+	}
+	return 0
+}

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -100,11 +100,19 @@ follow the instructions for **your platform** below:
   </TabItem>
 </Tabs>
 
+## Update
+
+The Oasis CLI includes a built-in command to upgrade to the latest version.
+To update, run `oasis update`.
+
+This will check for a newer version on GitHub, show you the release notes,
+and ask for confirmation before downloading and replacing the current binary.
+
+## Configuration
+
 When running the Oasis CLI for the first time, it will generate a configuration
 file and populate it with the current Mainnet and Testnet networks. It will also
 configure all [ParaTimes supported by the Oasis Foundation][paratimes].
-
-## Configuration
 
 The configuration folder of Oasis CLI is located:
 

--- a/examples/setup/first-run.out
+++ b/examples/setup/first-run.out
@@ -13,6 +13,7 @@ Available Commands:
   paratime    ParaTime layer operations
   rofl        ROFL app management
   transaction Raw transaction operations
+  update      Download and install the newest Oasis CLI release
   wallet      Manage accounts in the local wallet
 
 Flags:

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/flatbuffers v24.12.23+incompatible // indirect
-	github.com/hashicorp/go-hclog v1.5.0 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.4.6 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
-github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-plugin v1.4.6 h1:MDV3UrKQBM3du3G7MApDGvOsMYy3JQJ4exhSoKBAeVA=
 github.com/hashicorp/go-plugin v1.4.6/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
<img width="821" height="336" alt="image" src="https://github.com/user-attachments/assets/5aea2d47-0241-4289-80c2-e17381b5ae30" />

resolves #551 

- with this feature, devs will be able to use `oasis udpate` command to have the latest version of oasis-cli across macOS/Linux/Windows