### PR TITLE
fix: Don't overwrite compose.yaml on rofl init

### DIFF
--- a/cmd/rofl/mgmt.go
+++ b/cmd/rofl/mgmt.go
@@ -710,9 +710,9 @@ func replaceArtifacts(manifest *buildRofl.Manifest, newArtifacts *buildRofl.Arti
 	return changes, nil
 }
 
-// detectAndCreateComposeFile detects the existing compose.yaml-like file and returns its filename. Otherwise, creates an empty default compose.yaml.
+// detectOrCreateComposeFile detects the existing compose.yaml-like file and returns its filename. If it doesn't exist, it creates compose.yaml and populates it.
 func detectOrCreateComposeFile() string {
-	for _, filename := range []string{"rofl-compose.yaml", "rofl-compose.yml", "docker-compose.yaml", "docker-compose.yml", "compose.yml"} {
+	for _, filename := range []string{"rofl-compose.yaml", "rofl-compose.yml", "docker-compose.yaml", "docker-compose.yml", "compose.yml", "compose.yaml"} {
 		if _, err := os.Stat(filename); err == nil {
 			return filename
 		}


### PR DESCRIPTION
Fixes regression caused by https://github.com/oasisprotocol/cli/pull/517.

If a compose file was called sth else than `compose.yaml` the init command left it intact, which is correct. But if the file was called `compose.yaml` it replaced it, even though it already existed on the disk.