### PR TITLE
docs: Document `oasis rofl top-up` command

### DIFF
--- a/cmd/rofl/common/flags.go
+++ b/cmd/rofl/common/flags.go
@@ -16,6 +16,9 @@ var (
 	// NoUpdateFlag is the flag for disabling the rofl.yaml manifest file update.
 	NoUpdateFlag *flag.FlagSet
 
+	// TermFlags provide the term and count setting.
+	TermFlags *flag.FlagSet
+
 	// DeploymentName is the name of the ROFL app deployment.
 	DeploymentName string
 
@@ -24,6 +27,12 @@ var (
 
 	// NoUpdate disables updating the rofl.yaml manifest file.
 	NoUpdate bool
+
+	// Term specifies the rental base unit.
+	Term string
+
+	// TermCount specific the rental base unit multiplier.
+	TermCount uint64
 )
 
 func init() {
@@ -35,4 +44,8 @@ func init() {
 
 	NoUpdateFlag = flag.NewFlagSet("", flag.ContinueOnError)
 	NoUpdateFlag.BoolVar(&NoUpdate, "no-update-manifest", false, "do not update the manifest")
+
+	TermFlags = flag.NewFlagSet("", flag.ContinueOnError)
+	TermFlags.StringVar(&Term, "term", "", "term to pay for in advance [hour, month, year]")
+	TermFlags.Uint64Var(&TermCount, "term-count", 1, "number of terms to pay for in advance")
 }

--- a/cmd/rofl/deploy.go
+++ b/cmd/rofl/deploy.go
@@ -38,8 +38,6 @@ var (
 	deployProvider       string
 	deployOffer          string
 	deployMachine        string
-	deployTerm           string
-	deployTermCount      uint64
 	deployForce          bool
 	deployShowOffers     bool
 	deployReplaceMachine bool
@@ -175,12 +173,12 @@ var (
 				showProviderOffer(ctx, offer)
 
 				term := detectTerm(offer)
-				if deployTermCount < 1 {
+				if roflCommon.TermCount < 1 {
 					return nil, nil, fmt.Errorf("number of terms must be at least 1")
 				}
 
 				// Calculate total price.
-				qTermCount := quantity.NewFromUint64(deployTermCount)
+				qTermCount := quantity.NewFromUint64(roflCommon.TermCount)
 				totalPrice, ok := offer.Payment.Native.Terms[term]
 				if !ok {
 					cobra.CheckErr("internal error: previously selected term not found in offer terms")
@@ -197,7 +195,7 @@ var (
 					Offer:      offer.ID,
 					Deployment: &machineDeployment,
 					Term:       term,
-					TermCount:  deployTermCount,
+					TermCount:  roflCommon.TermCount,
 				})
 
 				var sigTx, meta any
@@ -334,11 +332,11 @@ func detectTerm(offer *roflmarket.Offer) (term roflmarket.Term) {
 		cobra.CheckErr(fmt.Errorf("no payment terms available for offer '%s'", offer.ID))
 	}
 
-	if deployTerm != "" {
+	if roflCommon.Term != "" {
 		// Custom deploy term.
-		term = roflCommon.ParseMachineTerm(deployTerm)
+		term = roflCommon.ParseMachineTerm(roflCommon.Term)
 		if _, ok := offer.Payment.Native.Terms[term]; !ok {
-			cobra.CheckErr(fmt.Errorf("term '%s' is not available for offer '%s'", deployTerm, offer.ID))
+			cobra.CheckErr(fmt.Errorf("term '%s' is not available for offer '%s'", roflCommon.Term, offer.ID))
 		}
 		return
 	}
@@ -454,8 +452,6 @@ func init() {
 	providerFlags.StringVar(&deployProvider, "provider", "", "set the provider address")
 	providerFlags.StringVar(&deployOffer, "offer", "", "set the provider's offer identifier")
 	providerFlags.StringVar(&deployMachine, "machine", buildRofl.DefaultMachineName, "machine to deploy into")
-	providerFlags.StringVar(&deployTerm, "term", "", "term to pay for in advance")
-	providerFlags.Uint64Var(&deployTermCount, "term-count", 1, "number of terms to pay for in advance")
 	providerFlags.BoolVar(&deployForce, "force", false, "force deployment")
 	providerFlags.BoolVar(&deployShowOffers, "show-offers", false, "show all provider offers and quit")
 	providerFlags.BoolVar(&deployReplaceMachine, "replace-machine", false, "rent a new machine if the provided one expired")
@@ -464,4 +460,5 @@ func init() {
 	deployCmd.Flags().AddFlagSet(providerFlags)
 	deployCmd.Flags().AddFlagSet(roflCommon.DeploymentFlags)
 	deployCmd.Flags().AddFlagSet(roflCommon.WipeFlags)
+	deployCmd.Flags().AddFlagSet(roflCommon.TermFlags)
 }

--- a/docs/rofl.md
+++ b/docs/rofl.md
@@ -194,6 +194,19 @@ offer:
 
 [ROFL marketplace]: https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/rofl/features/marketplace.mdx
 
+## Top-up payment for the machine {#top-up}
+
+Run `rofl machine top-up` to extend the rental of the machine obtained from
+the [ROFL marketplace]. The rental is extended under the terms of the original
+offer. Specify the extension period with [`--term`][term-flags] and
+[`--term-count`][term-flags] parameters.
+
+![code shell](../examples/rofl/machine-top-up.in.static)
+
+![code](../examples/rofl/machine-top-up.out.static)
+
+[term-flags]: #deploy
+
 ## Advanced
 
 ### Upgrade ROFL app dependencies {#upgrade}

--- a/examples/rofl/deploy.out.static
+++ b/examples/rofl/deploy.out.static
@@ -41,4 +41,5 @@ Transaction hash: bce96976f38485546b5950f8b2a7f9b7c43b9656935cc472a90680187469f4
 Execution successful.
 Created machine: 0000000000000000
 Deployment into machine scheduled.
-Use `oasis rofl machine show` to see status.
+This machine expires on 2025-08-07 12:35:47 +0200 CEST. Use `oasis rofl machine top-up` to extend it.
+Use `oasis rofl machine show` to check status.

--- a/examples/rofl/machine-top-up.in.static
+++ b/examples/rofl/machine-top-up.in.static
@@ -1,0 +1,1 @@
+oasis rofl machine top-up --term hour --term-count 12

--- a/examples/rofl/machine-top-up.out.static
+++ b/examples/rofl/machine-top-up.out.static
@@ -1,0 +1,34 @@
+Using provider:     oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz (oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz)
+Top-up machine:     default [000000000000022a]
+Top-up term:        12 x hour
+Unlock your account.
+? Passphrase: 
+You are about to sign the following transaction:
+Format: plain
+Method: roflmarket.InstanceTopUp
+Body:
+  {
+    "provider": "oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz",
+    "id": "000000000000022a",
+    "term": 1,
+    "term_count": 12
+  }
+Authorized signer(s):
+  1. AyZKkxNFeyqLI5HGTYqEmCcYxKGo/kueOzSHzdnrSePO (secp256k1eth)
+     Nonce: 996
+Fee:
+  Amount: 0.0013614 TEST
+  Gas limit: 13614
+  (gas price: 0.0000001 TEST per gas unit)
+
+Network:  testnet
+ParaTime: sapphire
+Account:  dave
+? Sign this transaction? Yes
+(In case you are using a hardware-based signer you may need to confirm on device.)
+Broadcasting transaction...
+Transaction included in block successfully.
+Round:            12917124
+Transaction hash: 094ddc21c39acd96789153003016bda5d2a0077e7be11635bb755b6c49c287ac
+Execution successful.
+Machine topped up.


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/cli/issues/525

When deploying a ROFL app, the following is added at the end

```
This machine expires on 2025-08-07 12:35:47 +0200 CEST. Use `oasis rofl machine top-up` to extend it.
```

This PR also moves `--term` and `--term-count` parameters to `roflCommon` to avoid redundancy and a check, if no `term` provided when topping up.