### PR TITLE
cmd/rofl: Fix crash when deploying to non-existent instance

### DIFF
--- a/cmd/rofl/deploy.go
+++ b/cmd/rofl/deploy.go
@@ -239,8 +239,8 @@ var (
 					if deployReplaceMachine {
 						fmt.Printf("Machine instance not found. Obtaining new one...")
 						machine.ID = ""
-						_, _, err = obtainMachine()
-						return nil, err
+						_, insDsc, err = obtainMachine()
+						return insDsc, err
 					}
 
 					cobra.CheckErr("Machine instance not found.\nTip: If your instance expired, run this command with --replace-machine flag to replace it with a new machine.")


### PR DESCRIPTION
This PR fixes regression caused by #525. CLI crashed if you have an expired machine ID in your manifest and you want to re-deploy with `oasis rofl deploy --replace-machine`.