### PR TITLE
rofl: Improve parsing failed validation error

### DIFF
--- a/cmd/rofl/build/validate.go
+++ b/cmd/rofl/build/validate.go
@@ -68,8 +68,7 @@ func validateComposeFile(composeFile string, manifest *buildRofl.Manifest) error
 	}
 	proj, err := options.LoadProject(context.Background())
 	if err != nil {
-		fmt.Println(err)
-		return fmt.Errorf("parsing failed")
+		return fmt.Errorf("parsing: %w", err)
 	}
 
 	// Keep track of all images encountered, as we will need them in later steps.


### PR DESCRIPTION
The rofl-app-backend uses `oasis rofl build --validate-only` to validate artifacts and captures errors from stderr. In this case, the specific (unhelpful) error shown is:

```
Error: compose file validation failed: parsing failed
```

This approach keeps error handling consistent with other failures, since all errors are surfaced via stderr.