### PR TITLE
docs: Fix link to new ROFL build chapter

### DIFF
--- a/docs/account.md
+++ b/docs/account.md
@@ -455,7 +455,7 @@ assets may still be [slashed][slashing].
 ### Public Key to Address {#from-public-key}
 
 `account from-public-key <public_key>` converts the Base64-encoded public key
-to the [Oasis native address](../terminology.md#address).
+to the [Oasis native address].
 
 ![code shell](../examples/account/from-public-key.in)
 
@@ -472,6 +472,8 @@ Oasis consensus transactions hold the public key of the signer instead of their
 signer's staking address on the network.
 
 :::
+
+[Oasis native address]: https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/terminology.md#address
 
 ### Non-Interactive Mode {#y}
 

--- a/docs/rofl.md
+++ b/docs/rofl.md
@@ -97,7 +97,7 @@ chapter for details.
 
 :::
 
-[ROFL Prerequisites]: https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/rofl/prerequisites.md
+[ROFL Prerequisites]: https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/rofl/workflow/prerequisites.md
 [npa]: ./account.md#npa
 
 ## Secrets management {#secret}


### PR DESCRIPTION
Part of https://github.com/oasisprotocol/docs/pull/1456