### PR TITLE
cmd/wallet/create: set default name

### DIFF
--- a/cmd/wallet/create.go
+++ b/cmd/wallet/create.go
@@ -15,12 +15,15 @@ import (
 var accKind string
 
 var createCmd = &cobra.Command{
-	Use:   "create <name>",
+	Use:   "create [<name>]",
 	Short: "Create a new account",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(_ *cobra.Command, args []string) {
 		cfg := config.Global()
-		name := args[0]
+		name := "account-1"
+		if len(args) > 0 {
+			name = args[0]
+		}
 
 		checkAccountExists(cfg, name)
 


### PR DESCRIPTION
This makes it possible to execute `oasis wallet create` without any arguments, and get a wallet called `test_wallet`.

The goal of this change is to get our CLI tool more inline with expectations (hallucinations) of AI coding tools, in order to decrease friction for new developers.