### PR TITLE
cmd/account/show: add balance alias

### DIFF
--- a/cmd/account/show/show.go
+++ b/cmd/account/show/show.go
@@ -28,7 +28,7 @@ var (
 	Cmd = &cobra.Command{
 		Use:     "show [address]",
 		Short:   "Show balance and other information",
-		Aliases: []string{"s"},
+		Aliases: []string{"s", "balance", "b"},
 		Args:    cobra.MaximumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			cfg := cliConfig.Global()


### PR DESCRIPTION
This makes it possible to execute `oasis account balance` and get the same result as `oasis account show`.

The goal of this change is to get our CLI tool more inline with expectations (hallucinations) of AI coding tools, by making it more similar to other tools on the market, in order to decrease friction for new developers.