### PR TITLE
Fix oasis rofl build for manfiests using a builder env

### DIFF
--- a/build/env/env.go
+++ b/build/env/env.go
@@ -145,6 +145,10 @@ func (de *ContainerEnv) WrapCommand(cmd *exec.Cmd) error {
 		"--platform", "linux/amd64",
 		"--workdir", workDir,
 	}
+	// Add interactive flag if stdin is set to allow piping data into the container.
+	if cmd.Stdin != nil {
+		cmd.Args = append(cmd.Args, "--interactive")
+	}
 	for hostDir, bindDir := range de.volumes {
 		cmd.Args = append(cmd.Args, "--volume", hostDir+":"+bindDir)
 	}

--- a/cmd/rofl/build/artifacts.go
+++ b/cmd/rofl/build/artifacts.go
@@ -359,12 +359,18 @@ func createSquashFs(buildEnv env.ExecEnv, fn, dir string) (int64, error) {
 	tarHash := hex.EncodeToString(tarHasher.Sum(nil))
 	fmt.Printf("TAR archive SHA256: %s\n", tarHash)
 
+	// Convert paths for container environment if needed.
+	fnInEnv, err := buildEnv.PathToEnv(fn)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert output path: %w", err)
+	}
+
 	// Convert tar to squashfs using sqfstar under fakeroot.
 	cmd := exec.Command(
 		fakerootBin,
 		"--",
 		sqfstarBin,
-		fn,
+		fnInEnv,
 		"-reproducible",
 		"-comp", "gzip",
 		"-b", "1M",


### PR DESCRIPTION
Found out while doing: https://github.com/oasisprotocol/oasis-sdk/pull/2402

Also confirmed this still works for ROFL apps that don't use the build env.