### PR TITLE
docs/network: Fix broken link

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -464,4 +464,4 @@ For example:
 
 ![code json](../examples/network/trust.out.static)
 
-[state sync]: https://github.com/oasisprotocol/docs/blob/main/docs/node/run-your-node/advanced/sync-node-using-state-sync.md#using-state-sync-for-quick-bootstrapping
+[state sync]: https://github.com/oasisprotocol/docs/blob/main/docs/node/run-your-node/advanced/sync-node-using-state-sync.md


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/docs/actions/runs/19626086942/job/56195086882?pr=1574.

(I originally copied the pattern from the sub-chapters, but in case of the heading no anchor will be created).
