### PR TITLE
Update Go to 1.25.4 and golangci-lint to v2

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.x"
           cache: false
       - name: Install gitlint
         run: |
@@ -61,9 +61,9 @@ jobs:
         # NOTE: Using the official golangci-lint GitHub Action should give
         # better performance than manually installing golangci-lint and running
         # 'make lint-go'.
-        uses: golangci/golangci-lint-action@v6.5.0
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.64
+          version: v2.6.2
         # Always run this step so that all linting errors can be seen at once.
         if: always()
       - name: Ensure a clean code checkout

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.x"
       - name: Cache Go dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/goreleaser/goreleaser-cross:v1.22.3
+      image: ghcr.io/goreleaser/goreleaser-cross:v1.25
       options: --user 1001
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.x"
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,6 @@
-# golangci-lint configuration.
-
-# For more information, see:
-# https://golangci-lint.run/usage/configuration/.
-
-run:
-  timeout: 5m
-
+version: "2"
 linters:
-  # Disable all linters except the ones explicitly listed below.
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bodyclose
@@ -16,74 +8,100 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exhaustive
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - gofumpt
     - goheader
-    - goimports
-    - revive
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - nestif
-    - noctx
     - nolintlint
     - prealloc
+    - revive
     - rowserrcheck
-    - staticcheck
-    - stylecheck
     - sqlclosecheck
-    - typecheck
+    - staticcheck
     - unconvert
     - unparam
     - unused
     - whitespace
-
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - $all
+          allow:
+            - $gostd
+            - golang.org/x/sys/unix
+            - golang.org/x/crypto/sha3
+            - golang.org/x/crypto/argon2
+            - github.com/oasisprotocol
+            - github.com/btcsuite/btcd
+            - github.com/adrg/xdg
+            - github.com/AlecAivazis/survey/v2
+            - github.com/ethereum/go-ethereum
+            - github.com/miguelmota/go-ethereum-hdwallet
+            - github.com/mitchellh/mapstructure
+            - github.com/olekukonko/tablewriter
+            - github.com/spf13/cobra
+            - github.com/spf13/pflag
+            - github.com/spf13/viper
+            - github.com/stretchr/testify
+            - github.com/tyler-smith/go-bip39
+            - github.com/zondax/ledger-go
+            - github.com/foxboron/go-uefi/authenticode
+            - golang.org/x/text
+            - gopkg.in/yaml.v3
+            - github.com/compose-spec/compose-go/v2
+            - github.com/github/go-spdx/v2
+            - github.com/opencontainers/image-spec/specs-go/v1
+            - oras.land/oras-go/v2
+            - github.com/wI2L/jsondiff
+            - github.com/google/uuid
+            - golang.org/x/net/idna
+            - golang.org/x/term
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package
+            - pkg: github.com/fxamacker/cbor/v2
+              desc: Use oasis-core/go/common/cbor instead
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        files:
-          - $all
-        allow:
-          - $gostd
-          - golang.org/x/sys/unix
-          - golang.org/x/crypto/sha3
-          - golang.org/x/crypto/argon2
-          - github.com/oasisprotocol
-          - github.com/btcsuite/btcd
-          - github.com/adrg/xdg
-          - github.com/AlecAivazis/survey/v2
-          - github.com/ethereum/go-ethereum
-          - github.com/miguelmota/go-ethereum-hdwallet
-          - github.com/mitchellh/mapstructure
-          - github.com/olekukonko/tablewriter
-          - github.com/spf13/cobra
-          - github.com/spf13/pflag
-          - github.com/spf13/viper
-          - github.com/stretchr/testify
-          - github.com/tyler-smith/go-bip39
-          - github.com/zondax/ledger-go
-          - github.com/foxboron/go-uefi/authenticode
-          - golang.org/x/text
-          - gopkg.in/yaml.v3
-          - github.com/compose-spec/compose-go/v2
-          - github.com/github/go-spdx/v2
-          - github.com/opencontainers/image-spec/specs-go/v1
-          - oras.land/oras-go/v2
-          - github.com/wI2L/jsondiff
-          - github.com/google/uuid
-          - golang.org/x/net/idna
-          - golang.org/x/term
-  exhaustive:
-    # Switch statements are to be considered exhaustive if a 'default' case is
-    # present, even if all enum members aren't listed in the switch.
-    default-signifies-exhaustive: true
+      - linters:
+          - revive
+        path: "/common/"
+        text: "var-naming: avoid meaningless package names"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/oasisprotocol/cli
+
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/common/transaction.go
+++ b/cmd/common/transaction.go
@@ -7,10 +7,11 @@ import (
 	"math"
 	"os"
 
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	coreSignature "github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -587,10 +588,12 @@ func PrettyErrorHints(
 		errMsg += "\nTip: You can get TEST tokens at https://faucet.testnet.oasis.io or #dev-central at https://oasis.io/discord."
 	}
 	if failedRes.Module == staking.ModuleName {
-		if failedRes.Code == 5 {
+		switch failedRes.Code {
+		case 5:
 			errMsg += "\nTip: Did you forget to run `oasis account allow`?"
-		} else if failedRes.Code == 9 {
+		case 9:
 			errMsg += "\nTip: You can see minimum staking transfer amount by running `oasis network show parameters`"
+		default:
 		}
 	}
 	return errMsg

--- a/cmd/common/wallet.go
+++ b/cmd/common/wallet.go
@@ -181,7 +181,8 @@ func ResolveAddress(net *configSdk.Network, address string) (*types.Address, *et
 		if len(subs) > 2 {
 			poolName = subs[2]
 		}
-		if poolKind == addressExplicitParaTime {
+		switch poolKind {
+		case addressExplicitParaTime:
 			switch poolName {
 			case poolCommon:
 				return &accounts.CommonPoolAddress, nil, nil
@@ -196,7 +197,7 @@ func ResolveAddress(net *configSdk.Network, address string) (*types.Address, *et
 			default:
 				return nil, nil, fmt.Errorf("unsupported ParaTime pool: %s", poolName)
 			}
-		} else if poolKind == addressExplicitConsensus {
+		case addressExplicitConsensus:
 			var addr types.Address
 			switch poolName {
 			case poolBurn:
@@ -211,8 +212,9 @@ func ResolveAddress(net *configSdk.Network, address string) (*types.Address, *et
 				return nil, nil, fmt.Errorf("unsupported consensus pool: %s", poolName)
 			}
 			return &addr, nil, nil
+		default:
+			return nil, nil, fmt.Errorf("unsupported pool kind: %s. Please use pool:<poolKind>:<poolName>, for example pool:paratime:pending-withdrawal", poolKind)
 		}
-		return nil, nil, fmt.Errorf("unsupported pool kind: %s. Please use pool:<poolKind>:<poolName>, for example pool:paratime:pending-withdrawal", poolKind)
 	case addressExplicitTest:
 		// test:alice, test:dave
 		if testKey, ok := testing.TestAccounts[data]; ok {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/oasisprotocol/cli
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.4
 
 // v1.5.0 has broken uint parsing, use a commit with the fix until the
 // the maintainers merge the PR: https://github.com/spf13/cast/pull/144


### PR DESCRIPTION
In most other Go projects we have already updated. So now we can use the same `golangci-lint` version as eleswhere.