### PR TITLE
Use builder by default and fail if --no-container and unsupported platform

### DIFF
--- a/build/rofl/artifacts.go
+++ b/build/rofl/artifacts.go
@@ -1,5 +1,8 @@
 package rofl
 
+// DefaultBuilderImage is the default builder container image to use when building ROFL apps.
+const DefaultBuilderImage = "ghcr.io/oasisprotocol/rofl-dev:v0.5.0@sha256:31573686552abeb0edebc450f6872831f0006a6cf38220cef7e0789d4376c2c1"
+
 // LatestBasicArtifacts are the latest TDX ROFL basic app artifacts.
 var LatestBasicArtifacts = ArtifactsConfig{
 	Firmware: "https://github.com/oasisprotocol/oasis-boot/releases/download/v0.6.2/ovmf.tdx.fd#db47100a7d6a0c1f6983be224137c3f8d7cb09b63bb1c7a5ee7829d8e994a42f",

--- a/build/sgxs/sgxs.go
+++ b/build/sgxs/sgxs.go
@@ -15,10 +15,10 @@ import (
 // It requires the `ftxsgx-elf2sgxs` utility to be installed.
 func Elf2Sgxs(buildEnv env.ExecEnv, elfSgxPath, sgxsPath string, heapSize, stackSize, threads uint64) (err error) {
 	if elfSgxPath, err = buildEnv.PathToEnv(elfSgxPath); err != nil {
-		return
+		return err
 	}
 	if sgxsPath, err = buildEnv.PathToEnv(sgxsPath); err != nil {
-		return
+		return err
 	}
 
 	args := []string{
@@ -31,7 +31,7 @@ func Elf2Sgxs(buildEnv env.ExecEnv, elfSgxPath, sgxsPath string, heapSize, stack
 
 	cmd := exec.Command("ftxsgx-elf2sgxs", args...)
 	if err = buildEnv.WrapCommand(cmd); err != nil {
-		return
+		return err
 	}
 	if common.IsVerbose() {
 		fmt.Println(cmd)

--- a/docs/rofl.md
+++ b/docs/rofl.md
@@ -98,6 +98,16 @@ Building ROFL apps does not require a working TEE on your machine. However, you
 do need to install all corresponding tools. Check out the [ROFL Prerequisites]
 chapter for details.
 
+Platform/container selection rules:
+
+- On Linux/amd64, builds are native by default unless the manifest specifies a
+  `builder` image; you can force native builds with `--no-container` even if a
+  `builder` is set.
+- On macOS/Windows/other architectures, builds always use a containerized
+  builder; `--no-container` will fail on these platforms.
+- If a containerized build is selected (due to platform or manifest), Docker or
+  Podman must be available; otherwise the build fails.
+
 :::
 
 [ROFL Prerequisites]: https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/rofl/workflow/prerequisites.md


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/cli/issues/652

TODO:
- [ ] actually maybe do as suggested in https://github.com/oasisprotocol/cli/issues/652#issuecomment-3585329855
- [ ] update [quickstart docs](https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/rofl/quickstart.mdx#build) to not recommend `docker run --platform linux/amd64 --volume .:/src -it ghcr.io/oasisprotocol/rofl-dev:main oasis rofl build` anymore, once this is released

`oasis rofl build` should now just work on all platforms.

Behaviour is something like:

 Host/arch | Manifest builder | Flag | Docker/podman available? | Result
  --- | --- | --- | --- | ---
  linux/amd64 | none | none | n/a | Native build
  linux/amd64 | set | none | yes | Container build (manifest image)
  linux/amd64 | set | none | no | Error: builder specified but no docker/podman
  linux/amd64 | any | --no-container | n/a | Native build (flag overrides)
  non-linux/other arch | any | --no-container | any | Error: native builds only on linux/amd64; remove --no-container
  non-linux/other arch | any | none | yes | Container build (manifest image if set, else default)
  non-linux/other arch | any | none | no | Error: native builds only on linux/amd64 and no docker/podman available