### PR TITLE
Fix `rofl machine show` crash if deployment not available

### DIFF
--- a/cmd/rofl/machine/show.go
+++ b/cmd/rofl/machine/show.go
@@ -128,7 +128,7 @@ func prettyPrintMachine(mCfg *machineCfg, out *machineShowOutput) {
 			fmt.Printf("Proxy:\n")
 			fmt.Printf("  Domain: %s\n", proxyDomain)
 
-			prettyPrintMachinePorts(mCfg.ExtraCfg, out.Machine.Deployment.AppID, out.Machine, proxyDomain)
+			prettyPrintMachinePorts(mCfg.ExtraCfg, out.Replica.App, out.Machine, proxyDomain)
 		}
 	}
 


### PR DESCRIPTION
If ROFL was being deployed, but not able to start up, `rofl machine show` crashed.