### PR TITLE
rofl: Add topup alias for top-up

### DIFF
--- a/cmd/rofl/machine/mgmt.go
+++ b/cmd/rofl/machine/mgmt.go
@@ -186,9 +186,10 @@ var (
 	}
 
 	topUpCmd = &cobra.Command{
-		Use:   "top-up [<machine-name> | <provider-address>:<machine-id>]",
-		Short: "Top-up payment for a machine",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "top-up [<machine-name> | <provider-address>:<machine-id>]",
+		Short:   "Top-up payment for a machine",
+		Aliases: []string{"topup"},
+		Args:    cobra.MaximumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
 			txCfg := common.GetTransactionConfig()
 


### PR DESCRIPTION
I always run `topup` and miss the dash for the first time ;) Let's make an alias.