### PR TITLE
Fix ci check examples

### DIFF
--- a/cmd/network/show.go
+++ b/cmd/network/show.go
@@ -93,6 +93,10 @@ func prettyPrintEntityNodes(ctx context.Context, npa *common.NPASelection, staki
 			ID:     node,
 		}
 
+		// TODO: Fix eager termination of pretty printing and handle the case
+		// where node descriptor has already expired, but node status still
+		// returns as debonding period has not yet passed.
+		// See: https://github.com/oasisprotocol/cli/issues/707.
 		nodeStatus, err := registryConn.GetNodeStatus(ctx, idQuery2)
 		if err != nil {
 			fmt.Println("  Node is not active")

--- a/examples/network-show/id-entity.in
+++ b/examples/network-show/id-entity.in
@@ -1,1 +1,1 @@
-oasis network show xQN6ffLSdc51EfEQ2BzltK1iWYAw6Y1CkBAbFzlhhEQ=
+oasis network show UjRo9HS8ho/tkzQZyJ7AD//CqOuH0YvXILKTpmfD3dg=


### PR DESCRIPTION
Fixes existing CI issue:



```bash
run make-examples

....

Running network-show/id-entity.in:
  /Users/runner/work/cli/cli/oasis network show xQN6ffLSdc51EfEQ2BzltK1iWYAw6Y1CkBAbFzlhhEQ= --config /tmp/cli_examples/network-show/cli.toml 
Error: could not get a node: registry: no such node
make: *** [examples/network-show/id-entity.out] Error 1
Error: Process completed with exit code 2.
```



E.g. see https://github.com/oasisprotocol/cli/actions/runs/28896146091/job/85721038314?pr=705